### PR TITLE
fix(frontend): add missing @nivo/treemap dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "@nivo/network": "^0.93.0",
     "@nivo/sankey": "^0.93.0",
     "@nivo/scatterplot": "^0.88.0",
+    "@nivo/treemap": "^0.88.0",
     "@tanstack/react-query": "5.29.2",
     "@types/d3": "^7.4.3",
     "@types/geojson": "^7946.0.16",


### PR DESCRIPTION
## Summary
- Adds the missing `@nivo/treemap` dependency to package.json
- Fixes the build error that occurs during `pnpm vite build` step

## Test plan
- [x] Verify that the CI build passes
- [ ] Run locally with `pnpm build` to confirm successful build

The build was failing with the error:
```
Error: [vite]: Rollup failed to resolve import "@nivo/treemap" from "/app/src/components/charts/NivoTreemapChart.tsx".
```

This PR adds the missing dependency to match the other @nivo packages.

🤖 Generated with [Claude Code](https://claude.ai/code)