### PR TITLE
fix(frontend): reduce SlotDataStore cache size to prevent memory leaks

### DIFF
--- a/frontend/src/utils/SlotDataStore.ts
+++ b/frontend/src/utils/SlotDataStore.ts
@@ -14,7 +14,7 @@ export interface SlotData {
 class SlotDataStore {
   private static instance: SlotDataStore;
   private slotDataCache: Map<string, SlotData> = new Map();
-  private maxCacheSize: number = 30; // Store data for up to 30 slots
+  private maxCacheSize: number = 5; // Store data for up to 5 slots
   private maxAgeMs: number = 5 * 60 * 1000; // 5 minutes
 
   // Private constructor for singleton


### PR DESCRIPTION
## Summary
- Reduces the maximum cache size in SlotDataStore from 30 slots to 5 slots
- Helps prevent memory leaks in the block production visualization by limiting the amount of slot data kept in memory
- More frequent cache cleanup while still maintaining a smooth user experience

## Test plan
- Test the block production visualization to ensure it still works properly with reduced cache size
- Verify that memory usage remains stable during extended use

🤖 Generated with [Claude Code](https://claude.ai/code)