### PR TITLE
Fix infinite loop when switching networks

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -75,7 +75,7 @@ function Layout(): JSX.Element {
             <div className="hidden lg:flex justify-center">
               <NetworkSelector
                 selectedNetwork={selectedNetwork}
-                onNetworkChange={setSelectedNetwork}
+                onNetworkChange={(network) => setSelectedNetwork(network, 'ui')}
                 className="w-48"
               />
             </div>
@@ -141,7 +141,7 @@ function Layout(): JSX.Element {
               <div className="p-4 border-b border-subtle">
                 <NetworkSelector
                   selectedNetwork={selectedNetwork}
-                  onNetworkChange={setSelectedNetwork}
+                  onNetworkChange={(network) => setSelectedNetwork(network, 'ui')}
                   className="w-full"
                 />
               </div>

--- a/frontend/src/contexts/NetworkContext.ts
+++ b/frontend/src/contexts/NetworkContext.ts
@@ -2,7 +2,7 @@ import { createContext } from 'react';
 
 interface NetworkContextType {
   selectedNetwork: string;
-  setSelectedNetwork: (network: string) => void;
+  setSelectedNetwork: (network: string, source?: 'ui' | 'url') => void;
   availableNetworks: string[];
 }
 


### PR DESCRIPTION
## Summary
- Fixed infinite loop issue that occurred when switching networks, especially when going from Holesky to Sepolia
- Added source tracking to network changes to break circular dependencies between effects
- Separated UI-initiated changes from URL-initiated changes to prevent feedback loops
- Added more detailed logging for easier debugging

## Test plan
- Tested switching networks directly via URL navigation
- Tested switching networks via network selector in top navbar
- Verified network changes are properly reflected in the block production view
- Verified network switches work in both directions without loops

🤖 Generated with [Claude Code](https://claude.ai/code)