### PR TITLE
fix(block-production): display dynamic block version instead of hardcoded DENEB

### DIFF
--- a/frontend/src/components/beacon/block_production/common/BlockHeader.tsx
+++ b/frontend/src/components/beacon/block_production/common/BlockHeader.tsx
@@ -87,10 +87,12 @@ const BlockHeader: React.FC<BlockHeaderProps> = ({
                 </div>
               )}
 
-              {/* Block Version - Always show "DENEB" but moved to far right */}
-              <div className="ml-auto bg-cyber-neon/10 px-2 py-0.5 rounded text-xs font-semibold text-cyber-neon uppercase tracking-wide">
-                DENEB
-              </div>
+              {/* Block Version - Try to get from any available source */}
+              {(blockData?.blockVersion || blockData?.raw?.block_version || blockData?.raw?.blockVersion) && (
+                <div className="ml-auto bg-cyber-neon/10 px-2 py-0.5 rounded text-xs font-semibold text-cyber-neon uppercase tracking-wide">
+                  {blockData?.blockVersion || blockData?.raw?.block_version || blockData?.raw?.blockVersion}
+                </div>
+              )}
             </div>
           </div>
         </div>
@@ -121,8 +123,8 @@ const BlockHeader: React.FC<BlockHeaderProps> = ({
         ) : null}
       </div>
 
-      {/* State Root & Block Proposer - Only show for current and future blocks */}
-      {!isPast && (
+      {/* State Root & Block Proposer - Only show for current and future blocks AND when we have a block */}
+      {!isPast && (blockData?.blockRoot || blockData?.executionPayloadBlockHash) && (
         <div className="flex justify-between items-center text-xs">
           <div className="flex items-center">
             <span className="text-text-tertiary mr-1">State Root:</span>
@@ -140,8 +142,8 @@ const BlockHeader: React.FC<BlockHeaderProps> = ({
         </div>
       )}
 
-      {/* Block Size - Only show for current and future blocks - removed compressed size */}
-      {!isPast && (
+      {/* Block Size - Only show for current and future blocks AND when we have a block */}
+      {!isPast && (blockData?.blockRoot || blockData?.executionPayloadBlockHash) && (
         <div className="flex justify-between items-center text-xs mt-1">
           <div className="flex items-center">
             <span className="text-text-tertiary mr-1">Size:</span>

--- a/frontend/src/components/beacon/block_production/common/blockDataNormalizer.ts
+++ b/frontend/src/components/beacon/block_production/common/blockDataNormalizer.ts
@@ -11,6 +11,7 @@ export interface NormalizedBlockData {
   stateRoot?: string;
   parentRoot?: string;
   proposerIndex?: number;
+  blockVersion?: string;
 
   // Execution payload info
   executionPayloadBlockHash?: string;
@@ -60,9 +61,7 @@ const safeNumberConversion = (value: any): number | undefined => {
  * Debugging helper to log field availability
  */
 function logFieldAvailability(field: string, value: any) {
-  if (value !== undefined && value !== null) {
-    console.log(`Field ${field} available:`, value);
-  }
+  // Function left for reference but logging disabled
 }
 
 /**
@@ -71,8 +70,7 @@ function logFieldAvailability(field: string, value: any) {
 export function normalizeBlockData(block?: BlockData): NormalizedBlockData | undefined {
   if (!block) return undefined;
 
-  // For debugging - inspect what fields are available
-  // console.log("Original block data:", block);
+  // Initialize the result object
 
   const result: NormalizedBlockData = {
     raw: block,
@@ -80,15 +78,9 @@ export function normalizeBlockData(block?: BlockData): NormalizedBlockData | und
 
   // Handle block root
   result.blockRoot = block.block_root || block.blockRoot;
-  if (result.blockRoot) {
-    console.log('Found blockRoot:', result.blockRoot);
-  }
 
   // Handle state root
   result.stateRoot = block.state_root || block.stateRoot;
-  if (result.stateRoot) {
-    console.log('Found stateRoot:', result.stateRoot);
-  }
 
   // Handle parent root
   result.parentRoot = block.parent_root || block.parentRoot;
@@ -99,10 +91,7 @@ export function normalizeBlockData(block?: BlockData): NormalizedBlockData | und
   // Handle slot
   result.slot = safeNumberConversion(block.slot);
 
-  // Debug log to check the execution payload structure
-  if (block.execution_payload) {
-    console.log('Found execution_payload object:', Object.keys(block.execution_payload));
-  }
+  // Check for execution payload
 
   // Handle execution payload block hash
   result.executionPayloadBlockHash =
@@ -197,6 +186,9 @@ export function normalizeBlockData(block?: BlockData): NormalizedBlockData | und
 
   // Handle slot time
   result.slotTime = safeNumberConversion(block.slotTime);
+
+  // Handle block version
+  result.blockVersion = block.block_version || block.blockVersion;
 
   return result;
 }

--- a/frontend/src/components/beacon/block_production/common/types.ts
+++ b/frontend/src/components/beacon/block_production/common/types.ts
@@ -3,6 +3,8 @@ import { Node, Proposer } from '@/api/gen/backend/pkg/server/proto/beacon_slots/
 export interface BlockData {
   block_root?: string;
   blockRoot?: string;
+  block_version?: string;
+  blockVersion?: string;
   execution_payload_block_hash?: string;
   executionPayloadBlockHash?: string;
   execution_payload_transactions_count?: number;


### PR DESCRIPTION
## Summary
- Updated block production view to show the actual block version from the data instead of hardcoded "DENEB"
- Added proper handling for the block_version field in the data normalizer
- Improved state hiding: block version, state root, and size now only display when a block is available

## Test plan
- Open the block production view
- Verify that the block version badge shows the actual version from the data
- Verify that state root and block size details are hidden until a block is available

🤖 Generated with [Claude Code](https://claude.ai/code)