### PR TITLE
feat(block-production): display validator entity in phase icons

### DIFF
--- a/frontend/src/components/beacon/block_production/common/PhaseIcons.tsx
+++ b/frontend/src/components/beacon/block_production/common/PhaseIcons.tsx
@@ -240,6 +240,15 @@ const PhaseIcons: React.FC<PhaseIconsProps> = ({
             ) : (
               <span>Built via external builder</span>
             )}
+            <div className="mt-1 text-xs">
+              {slotData?.entity ? (
+                <>Validator: {slotData.entity}</>
+              ) : (
+                proposer.proposerValidatorIndex && (
+                  <>Validator index: {proposer.proposerValidatorIndex}</>
+                )
+              )}
+            </div>
           </>
         ) : (
           <>Waiting...</>


### PR DESCRIPTION
## Summary
- Add validator entity or proposer index display in the proposer stage of the phase icons component
- When available, show the entity name (e.g., "whale_0xf84a"), otherwise fall back to showing the proposer validator index

## Test plan
- Verified the implementation works with slot 11647807 which contains an entity named "whale_0xf84a"
- Ensured proper fallback to validator index when entity is not available
- Tested that the implementation works in both desktop and mobile views

🤖 Generated with [Claude Code](https://claude.ai/code)