### PR TITLE
Fix block production layout and UI improvements

### DIFF
--- a/frontend/src/components/beacon/BlockchainVisualization.tsx
+++ b/frontend/src/components/beacon/BlockchainVisualization.tsx
@@ -345,16 +345,16 @@ const BlockchainVisualization: React.FC<BlockchainVisualizationProps> = ({
           {/* Blocks - now arranged horizontally */}
           <div className="relative z-10 flex flex-row items-center justify-center gap-6 px-4 w-full h-full">
             {blockData.map(block => {
-              // Hide previous and next blocks on medium screens (< 1280px)
-              // Only show them on large screens (>= 1280px)
+              // Hide previous and next blocks on screens below 1536px (2xl)
+              // Only show them on extra large screens (>= 1536px)
               const visibilityClassNames = !block.isCurrentSlot 
-                ? 'hidden lg:flex' // Hide on medium screens, show on large screens
+                ? 'hidden 2xl:flex' // Hide on smaller screens, show only on 2xl screens (1536px+)
                 : 'flex'; // Always show current block
               
               // Calculate flex layout based on whether this is the current slot or not
               const flexClassNames = block.isCurrentSlot
-                ? 'w-full lg:w-[40%]' // Full width on medium screens, 40% on large screens
-                : 'lg:w-[30%]'; // 30% width on large screens only
+                ? 'w-full 2xl:w-[40%]' // Full width on smaller screens, 40% on 2xl screens
+                : '2xl:w-[30%]'; // 30% width on 2xl screens only
 
               // Only use PendingBlock for future blocks
               if (block.isFuture) {

--- a/frontend/src/components/beacon/BlockchainVisualization.tsx
+++ b/frontend/src/components/beacon/BlockchainVisualization.tsx
@@ -345,17 +345,23 @@ const BlockchainVisualization: React.FC<BlockchainVisualizationProps> = ({
           {/* Blocks - now arranged horizontally */}
           <div className="relative z-10 flex flex-row items-center justify-center gap-6 px-4 w-full h-full">
             {blockData.map(block => {
+              // Hide previous and next blocks on medium screens (< 1280px)
+              // Only show them on large screens (>= 1280px)
+              const visibilityClassNames = !block.isCurrentSlot 
+                ? 'hidden lg:flex' // Hide on medium screens, show on large screens
+                : 'flex'; // Always show current block
+              
               // Calculate flex layout based on whether this is the current slot or not
               const flexClassNames = block.isCurrentSlot
-                ? 'w-[40%]' // Make current block 40% width
-                : 'w-[30%]'; // Make other blocks 30% width
+                ? 'w-full lg:w-[40%]' // Full width on medium screens, 40% on large screens
+                : 'lg:w-[30%]'; // 30% width on large screens only
 
               // Only use PendingBlock for future blocks
               if (block.isFuture) {
                 return (
                   <div
                     key={block.slot}
-                    className={`flex items-center justify-center h-full ${flexClassNames} transition-all duration-300`}
+                    className={`${visibilityClassNames} items-center justify-center h-full ${flexClassNames} transition-all duration-300`}
                   >
                     <PendingBlock
                       slot={block.slot}
@@ -373,7 +379,7 @@ const BlockchainVisualization: React.FC<BlockchainVisualizationProps> = ({
               return (
                 <div
                   key={block.slot}
-                  className={`flex items-center justify-center h-full ${flexClassNames} transition-all duration-300`}
+                  className={`${visibilityClassNames} items-center justify-center h-full ${flexClassNames} transition-all duration-300`}
                 >
                   <BlockDetailsPanel
                     slot={block.slot}

--- a/frontend/src/components/beacon/block_production/common/BlockContent.tsx
+++ b/frontend/src/components/beacon/block_production/common/BlockContent.tsx
@@ -182,7 +182,7 @@ const BlockContent: React.FC<BlockContentProps> = ({
               <div className="w-1 h-4 bg-bg-surface-raised rounded-full mr-2"></div>
               <span className="text-xs text-text-tertiary uppercase mr-2">Hash:</span>
               <span className="text-xs font-medium text-text-secondary font-mono">
-                {formatHash(blockData.executionPayloadBlockHash, 8, 8)}
+                {formatHash(blockData.executionPayloadBlockHash)}
               </span>
             </div>
           )}
@@ -193,7 +193,7 @@ const BlockContent: React.FC<BlockContentProps> = ({
               <div className="w-1 h-4 bg-bg-surface-raised rounded-full mr-2"></div>
               <span className="text-xs text-text-tertiary uppercase mr-2">Recipient:</span>
               <span className="text-xs font-medium text-text-secondary font-mono">
-                {formatHash(blockData.executionPayloadFeeRecipient, 6, 4)}
+                {formatHash(blockData.executionPayloadFeeRecipient)}
               </span>
             </div>
           )}
@@ -248,7 +248,7 @@ const BlockContent: React.FC<BlockContentProps> = ({
               <div className="w-1 h-4 bg-bg-surface-raised rounded-full mr-2"></div>
               <span className="text-xs text-text-tertiary uppercase mr-2">Parent:</span>
               <span className="text-xs font-medium text-text-secondary font-mono">
-                {formatHash(blockData.executionPayloadParentHash, 6, 4)}
+                {formatHash(blockData.executionPayloadParentHash)}
               </span>
             </div>
           )}

--- a/frontend/src/components/beacon/block_production/common/BlockHeader.tsx
+++ b/frontend/src/components/beacon/block_production/common/BlockHeader.tsx
@@ -129,7 +129,7 @@ const BlockHeader: React.FC<BlockHeaderProps> = ({
           <div className="flex items-center">
             <span className="text-text-tertiary mr-1">State Root:</span>
             <span className="text-text-secondary font-mono">
-              {formatHash(blockData?.stateRoot, 6, 6)}
+              {formatHash(blockData?.stateRoot)}
             </span>
           </div>
 

--- a/frontend/src/components/beacon/block_production/common/PhaseIcons.tsx
+++ b/frontend/src/components/beacon/block_production/common/PhaseIcons.tsx
@@ -240,12 +240,18 @@ const PhaseIcons: React.FC<PhaseIconsProps> = ({
             ) : (
               <span>Built via external builder</span>
             )}
-            <div className="mt-1 text-xs">
+            <div className="mt-1 text-xs truncate max-w-full">
               {slotData?.entity ? (
-                <>Validator: {slotData.entity}</>
+                <span className="truncate block" title={`Validator: ${slotData.entity}`}>
+                  {slotData.entity.length > 12 
+                    ? `${slotData.entity.substring(0, 10)}...` 
+                    : slotData.entity}
+                </span>
               ) : (
                 proposer.proposerValidatorIndex && (
-                  <>Validator index: {proposer.proposerValidatorIndex}</>
+                  <span className="truncate block">
+                    Val: {proposer.proposerValidatorIndex}
+                  </span>
                 )
               )}
             </div>
@@ -366,12 +372,12 @@ const PhaseIcons: React.FC<PhaseIconsProps> = ({
 
   return (
     <div className="w-full px-4 sm:px-6 md:px-10">
-      {/* Container with fixed width for each phase and flow lines in between */}
-      <div className="grid grid-cols-11 w-full">
+      {/* Container with responsive grid for phases and flow lines */}
+      <div className="grid grid-cols-11 w-full min-w-0">
         {phases.map((phase, index) => (
           <React.Fragment key={phase.id}>
             {/* Each phase gets its own column */}
-            <div className="col-span-1 flex flex-col items-center">
+            <div className="col-span-1 flex flex-col items-center min-w-0">
               {/* Icon */}
               <div 
                 className={`w-14 h-14 flex items-center justify-center rounded-full shadow-md transition-colors duration-300 relative ${
@@ -409,7 +415,7 @@ const PhaseIcons: React.FC<PhaseIconsProps> = ({
                   isActiveInPhase(phase.id as any) ? 'opacity-100' : 'opacity-60'
                 }`}
               >
-                <span className={`${isActiveInPhase(phase.id as any) ? 'text-white/90' : 'text-tertiary'}`}>
+                <span className={`${isActiveInPhase(phase.id as any) ? 'text-white/90' : 'text-tertiary'} line-clamp-4 break-words`}>
                   {phase.description}
                 </span>
               </div>
@@ -427,7 +433,7 @@ const PhaseIcons: React.FC<PhaseIconsProps> = ({
                     <div className={`h-2 w-2/3 rounded-full bg-${phase.color}-400/20 animate-pulse`}></div>
                   </div>
                 ) : (
-                  <span className={`${isActiveInPhase(phase.id as any) ? `text-${phase.color}-300` : 'text-tertiary'}`}>
+                  <span className={`${isActiveInPhase(phase.id as any) ? `text-${phase.color}-300` : 'text-tertiary'} break-words line-clamp-3`}>
                     {getDynamicContent(phase.id)}
                   </span>
                 )}

--- a/frontend/src/components/beacon/block_production/common/blockDataNormalizer.ts
+++ b/frontend/src/components/beacon/block_production/common/blockDataNormalizer.ts
@@ -210,10 +210,12 @@ export function calculateBlobCount(normalizedBlock?: NormalizedBlockData): numbe
 /**
  * Format a hash string for display
  */
-export function formatHash(hash?: string, startChars = 6, endChars = 4): string {
+export function formatHash(hash?: string, startChars = 5, endChars = 0): string {
   if (!hash) return '—';
-  if (hash.length <= startChars + endChars) return hash;
-  return `${hash.substring(0, startChars)}...${hash.substring(hash.length - endChars)}`;
+  if (hash.length <= startChars) return hash;
+  return endChars > 0 
+    ? `${hash.substring(0, startChars)}...${hash.substring(hash.length - endChars)}`
+    : `${hash.substring(0, startChars)}...`;
 }
 
 /**

--- a/frontend/src/components/beacon/block_production/desktop/BuildersRelaysPanel.tsx
+++ b/frontend/src/components/beacon/block_production/desktop/BuildersRelaysPanel.tsx
@@ -214,22 +214,23 @@ const BuildersRelaysPanel: React.FC<BuildersRelaysPanelProps> = ({
                       marginBottom: '0.25rem',
                     }}
                   >
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center flex-1">
+                    <div className="flex items-center w-full">
+                      <div className="flex items-center w-[70%] min-w-0 overflow-hidden">
                         <div
                           className={`w-2 h-2 rounded-full mr-2 flex-shrink-0 ${showWinningStyle ? 'bg-amber-400' : 'bg-accent-muted'}`}
                         ></div>
-                        <div className="truncate flex-1">
+                        <div className="truncate min-w-0 max-w-full overflow-hidden">
                           <span
-                            className={`${showWinningStyle ? 'font-medium text-amber-400' : ''}`}
+                            className={`${showWinningStyle ? 'font-medium text-amber-400' : ''} truncate block overflow-hidden`}
+                            title={item.label}
                           >
                             {item.label}
                           </span>
                         </div>
                       </div>
-                      <div className="font-mono ml-1.5 rounded-md px-1.5 py-0.25">
+                      <div className="font-mono ml-1.5 rounded-md px-1.5 py-0.25 w-[30%] flex-shrink-0 text-right">
                         <span
-                          className={`${showWinningStyle ? 'text-amber-400 font-semibold' : 'text-secondary'} text-xs`}
+                          className={`${showWinningStyle ? 'text-amber-400 font-semibold' : 'text-secondary'} text-xs whitespace-nowrap`}
                         >
                           {item.value ? item.value.toFixed(4) : '0.0000'} ETH
                         </span>
@@ -283,20 +284,23 @@ const BuildersRelaysPanel: React.FC<BuildersRelaysPanelProps> = ({
                         : 'bg-surface/20 hover:bg-surface/30 border-l-2 border-subtle/30'
                     }`}
                   >
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center flex-1">
+                    <div className="flex items-center w-full">
+                      <div className="flex items-center w-[70%] min-w-0 overflow-hidden">
                         <div
                           className={`w-2 h-2 rounded-full mr-2 flex-shrink-0 ${showWinningStyle ? 'bg-amber-400' : 'bg-accent-muted'}`}
                         ></div>
-                        <div
-                          className={`truncate flex-1 ${showWinningStyle ? 'text-amber-400 font-medium' : 'text-xs'}`}
-                        >
-                          {item.label}
+                        <div className="truncate min-w-0 max-w-full overflow-hidden">
+                          <span
+                            className={`${showWinningStyle ? 'text-amber-400 font-medium' : 'text-xs'} truncate block overflow-hidden`}
+                            title={item.label}
+                          >
+                            {item.label}
+                          </span>
                         </div>
                       </div>
-                      <div className="flex items-center ml-1.5">
+                      <div className="w-[30%] flex-shrink-0 text-right ml-1.5">
                         <div
-                          className={`font-mono ${showWinningStyle ? 'text-amber-400' : 'text-tertiary'} text-[10px]`}
+                          className={`font-mono ${showWinningStyle ? 'text-amber-400' : 'text-tertiary'} text-[10px] whitespace-nowrap`}
                         >
                           {item.bidCount !== undefined
                             ? `${item.bidCount} bid${item.bidCount !== 1 ? 's' : ''}`

--- a/frontend/src/pages/beacon/block-production/live.tsx
+++ b/frontend/src/pages/beacon/block-production/live.tsx
@@ -50,8 +50,8 @@ export default function BlockProductionLivePage() {
     return () => window.removeEventListener('resize', checkScreenSize);
   }, []);
   
-  // Simplified check for mobile view (either mobile or tablet uses the mobile view)
-  const isMobile = viewMode !== 'desktop';
+  // Only use mobile view for real mobile devices, use desktop view for tablets
+  const isMobile = viewMode === 'mobile';
 
   // Use BeaconClockManager for slot timing
   const beaconClockManager = BeaconClockManager.getInstance();


### PR DESCRIPTION
## Summary
- Improves the responsive layout for block production visualization on medium-sized screens
- Fixes builder bids and MEV relay lists with proper text truncation using a 70/30 flexbox layout
- Updates tablet view to use desktop layout instead of mobile view for better user experience
- Updates hash display in block visualization to show only the first 5 characters for cleaner UI
- Hides previous/next blocks on all screens below 1536px width, showing only the current block for better focus

## Test plan
- Tested on multiple screen sizes: extra large desktop (1536px+), large desktop (1300px), medium desktop (1100px), tablet (900px)
- Verified proper text truncation and layout in builder/relay lists
- Ensured phase icons display correctly on all viewport sizes
- Verified all hash displays are showing 5 characters with ellipsis
- Confirmed that previous/next blocks are hidden on all screens below 1536px and visible only on 2xl screens

🤖 Generated with [Claude Code](https://claude.ai/code)