### PR TITLE
Fix: Use delivered_payloads to identify winning relays

### DIFF
--- a/frontend/src/components/beacon/block_production/desktop/BuildersRelaysPanel.tsx
+++ b/frontend/src/components/beacon/block_production/desktop/BuildersRelaysPanel.tsx
@@ -181,21 +181,21 @@ const BuildersRelaysPanel: React.FC<BuildersRelaysPanelProps> = ({
       }
     });
 
-    // Convert map to array and sort:
-    // 1. Winning relays first (relays in delivered_payloads)
-    // 2. Then sort non-winning relays by their highest bid value
+    // Convert map to array and sort by different rules depending on the phase
     return Array.from(uniqueRelays.values()).sort((a, b) => {
-      // Always put winning relays first
-      if (a.isWinning && !b.isWinning) return -1;
-      if (!a.isWinning && b.isWinning) return 1;
-      
-      // For non-winning relays, sort by highest bid value
-      if (!a.isWinning && !b.isWinning) {
+      // In building phase, sort purely by bid value (highest first)
+      if (currentPhase === Phase.Building) {
         return b.value - a.value;
       }
       
-      // For winning relays (if there are multiple), sort alphabetically
-      return a.relayName.localeCompare(b.relayName);
+      // After building phase:
+      // 1. Winning relays first (relays in delivered_payloads)
+      // 2. Then sort non-winning relays by their highest bid value
+      if (a.isWinning && !b.isWinning) return -1;
+      if (!a.isWinning && b.isWinning) return 1;
+      
+      // For relays in the same winning/non-winning category, sort by value
+      return b.value - a.value;
     });
   }, [bids, currentTime, winningBid]);
 
@@ -225,8 +225,8 @@ const BuildersRelaysPanel: React.FC<BuildersRelaysPanelProps> = ({
             <div className="space-y-1.5 p-2">
               {/* Show top 7 builders */}
               {builders.slice(0, 7).map(item => {
-                // Always show winning styling for delivered relays, regardless of phase
-                const showWinningStyle = item.isWinning;
+                // Only show winning styling after the building phase
+                const showWinningStyle = item.isWinning && currentPhase !== Phase.Building;
 
                 return (
                   <div
@@ -298,8 +298,8 @@ const BuildersRelaysPanel: React.FC<BuildersRelaysPanelProps> = ({
           {relays.length > 0 ? (
             <div className="space-y-1.5 p-2">
               {relays.slice(0, 5).map(item => {
-                // Always show winning styling for delivered relays, regardless of phase
-                const showWinningStyle = item.isWinning;
+                // Only show winning styling after the building phase
+                const showWinningStyle = item.isWinning && currentPhase !== Phase.Building;
 
                 return (
                   <div

--- a/frontend/src/components/beacon/block_production/desktop/BuildersRelaysPanel.tsx
+++ b/frontend/src/components/beacon/block_production/desktop/BuildersRelaysPanel.tsx
@@ -183,10 +183,18 @@ const BuildersRelaysPanel: React.FC<BuildersRelaysPanelProps> = ({
 
     // Convert map to array and sort:
     // 1. Winning relays first (relays in delivered_payloads)
-    // 2. Then alphabetically for non-winning relays
+    // 2. Then sort non-winning relays by their highest bid value
     return Array.from(uniqueRelays.values()).sort((a, b) => {
+      // Always put winning relays first
       if (a.isWinning && !b.isWinning) return -1;
       if (!a.isWinning && b.isWinning) return 1;
+      
+      // For non-winning relays, sort by highest bid value
+      if (!a.isWinning && !b.isWinning) {
+        return b.value - a.value;
+      }
+      
+      // For winning relays (if there are multiple), sort alphabetically
       return a.relayName.localeCompare(b.relayName);
     });
   }, [bids, currentTime, winningBid]);

--- a/frontend/src/components/beacon/block_production/desktop/BuildersRelaysPanel.tsx
+++ b/frontend/src/components/beacon/block_production/desktop/BuildersRelaysPanel.tsx
@@ -119,6 +119,18 @@ const BuildersRelaysPanel: React.FC<BuildersRelaysPanelProps> = ({
   }, [bids, currentTime]);
 
   // Get unique relay items - filtered by current time
+  // For debugging
+  useEffect(() => {
+    // Always log phase changes to help debug
+    console.log(`BuildersRelaysPanel: currentPhase=${currentPhase}, 
+                 hasWinningBid=${!!winningBid}, 
+                 hasDeliveredRelays=${!!winningBid?.deliveredRelays?.length}`);
+    
+    if (winningBid?.deliveredRelays?.length > 0) {
+      console.log(`BuildersRelaysPanel: deliveredRelays=`, winningBid.deliveredRelays);
+    }
+  }, [winningBid, currentPhase, currentTime]);
+
   const relays = useMemo(() => {
     // Filter bids by current time first
     const timeFilteredBids = bids.filter(bid => bid.time <= currentTime);
@@ -197,7 +209,7 @@ const BuildersRelaysPanel: React.FC<BuildersRelaysPanelProps> = ({
       // For relays in the same winning/non-winning category, sort by value
       return b.value - a.value;
     });
-  }, [bids, currentTime, winningBid]);
+  }, [bids, currentTime, winningBid, currentPhase]);
 
   return (
     <div className="flex flex-col space-y-3 h-full">
@@ -226,7 +238,9 @@ const BuildersRelaysPanel: React.FC<BuildersRelaysPanelProps> = ({
               {/* Show top 7 builders */}
               {builders.slice(0, 7).map(item => {
                 // Only show winning styling after the building phase
-                const showWinningStyle = item.isWinning && currentPhase !== Phase.Building;
+                // Re-evaluate this each render with the latest phase value
+                const isWinningBuilder = !!winningBid?.builderPubkey && item.builderPubkey === winningBid.builderPubkey;
+                const showWinningStyle = isWinningBuilder && currentPhase !== Phase.Building;
 
                 return (
                   <div
@@ -299,7 +313,9 @@ const BuildersRelaysPanel: React.FC<BuildersRelaysPanelProps> = ({
             <div className="space-y-1.5 p-2">
               {relays.slice(0, 5).map(item => {
                 // Only show winning styling after the building phase
-                const showWinningStyle = item.isWinning && currentPhase !== Phase.Building;
+                // Re-evaluate this each render with the latest phase value
+                const isWinningRelay = !!winningBid?.deliveredRelays?.includes(item.relayName);
+                const showWinningStyle = isWinningRelay && currentPhase !== Phase.Building;
 
                 return (
                   <div

--- a/frontend/src/components/beacon/block_production/desktop/BuildersRelaysPanel.tsx
+++ b/frontend/src/components/beacon/block_production/desktop/BuildersRelaysPanel.tsx
@@ -225,8 +225,8 @@ const BuildersRelaysPanel: React.FC<BuildersRelaysPanelProps> = ({
             <div className="space-y-1.5 p-2">
               {/* Show top 7 builders */}
               {builders.slice(0, 7).map(item => {
-                // Only show winning styling if we're not in building phase
-                const showWinningStyle = item.isWinning && currentPhase !== Phase.Building;
+                // Always show winning styling for delivered relays, regardless of phase
+                const showWinningStyle = item.isWinning;
 
                 return (
                   <div
@@ -298,8 +298,8 @@ const BuildersRelaysPanel: React.FC<BuildersRelaysPanelProps> = ({
           {relays.length > 0 ? (
             <div className="space-y-1.5 p-2">
               {relays.slice(0, 5).map(item => {
-                // Only show winning styling if we're not in building phase
-                const showWinningStyle = item.isWinning && currentPhase !== Phase.Building;
+                // Always show winning styling for delivered relays, regardless of phase
+                const showWinningStyle = item.isWinning;
 
                 return (
                   <div


### PR DESCRIPTION
## Summary
- Fixed MEV relay winner identification to check delivered_payloads
- Adds a visual indicator (checkmark) for relays that actually delivered payloads
- Ensures all relays in delivered_payloads are shown even if they have no bids

## Test plan
1. View a slot with delivered payloads
2. Verify that relays in the delivered_payloads data are shown with a checkmark
3. Verify that these relays are highlighted as winners

🤖 Generated with [Claude Code](https://claude.ai/code)