### PR TITLE
Fix winning relay detection logic

### DIFF
--- a/frontend/src/components/beacon/block_production/common/types.ts
+++ b/frontend/src/components/beacon/block_production/common/types.ts
@@ -32,6 +32,7 @@ export interface WinningBidData {
   value: number;
   relayName: string;
   builderPubkey?: string;
+  deliveredRelays?: string[]; // Array of relay names that delivered the payload
 }
 
 export interface TimeRange {

--- a/frontend/src/components/beacon/block_production/common/types.ts
+++ b/frontend/src/components/beacon/block_production/common/types.ts
@@ -32,7 +32,7 @@ export interface WinningBidData {
   value: number;
   relayName: string;
   builderPubkey?: string;
-  deliveredRelays?: string[]; // Array of relay names that delivered the payload
+  deliveredRelays?: string[];
 }
 
 export interface TimeRange {

--- a/frontend/src/components/beacon/block_production/desktop/BuildersRelaysPanel.tsx
+++ b/frontend/src/components/beacon/block_production/desktop/BuildersRelaysPanel.tsx
@@ -136,7 +136,6 @@ const BuildersRelaysPanel: React.FC<BuildersRelaysPanelProps> = ({
           id: `relay-${relayName}`,
           relayName: relayName,
           label: relayName,
-          // Using semantic colors instead of hardcoded ones - success color for winning relay
           // Mark relay as winning if it's in the deliveredPayloads list or it matches the winning bid relay
           isWinning:
             (winningBid?.deliveredRelays && winningBid.deliveredRelays.includes(relayName)) ||
@@ -164,6 +163,29 @@ const BuildersRelaysPanel: React.FC<BuildersRelaysPanelProps> = ({
         }
       }
     });
+
+    // Add relays from deliveredPayloads that might not be in the bids
+    if (winningBid?.deliveredRelays) {
+      winningBid.deliveredRelays.forEach(relayName => {
+        if (!uniqueRelays.has(relayName)) {
+          // Add relay from deliveredPayloads that wasn't in the bids
+          uniqueRelays.set(relayName, {
+            id: `relay-${relayName}`,
+            relayName: relayName,
+            label: relayName,
+            isWinning: true, // This is a winning relay since it's in deliveredPayloads
+            value: 0, // No bid value available
+            time: 0, // No bid time available
+            bidCount: 0, // No bids
+            isDeliveredOnly: true, // Flag to identify relays that only appear in deliveredPayloads
+          });
+        } else {
+          // Update existing relay to mark it as winning if it's in deliveredPayloads
+          const relay = uniqueRelays.get(relayName);
+          relay.isWinning = true;
+        }
+      });
+    }
 
     // Convert map to array and sort (winning relay first, then alphabetically)
     return Array.from(uniqueRelays.values()).sort((a, b) => {
@@ -302,9 +324,11 @@ const BuildersRelaysPanel: React.FC<BuildersRelaysPanelProps> = ({
                         <div
                           className={`font-mono ${showWinningStyle ? 'text-amber-400' : 'text-tertiary'} text-[10px] whitespace-nowrap`}
                         >
-                          {item.bidCount !== undefined
-                            ? `${item.bidCount} bid${item.bidCount !== 1 ? 's' : ''}`
-                            : '0 bids'}
+                          {item.isDeliveredOnly
+                            ? 'Delivered'
+                            : (item.bidCount !== undefined
+                              ? `${item.bidCount} bid${item.bidCount !== 1 ? 's' : ''}`
+                              : '0 bids')}
                         </div>
                       </div>
                     </div>

--- a/frontend/src/components/beacon/block_production/mobile/MobileBlockProductionView.tsx
+++ b/frontend/src/components/beacon/block_production/mobile/MobileBlockProductionView.tsx
@@ -264,11 +264,13 @@ const MobileBlockProductionView: React.FC<MobileBlockProductionViewProps> = ({
             isActive={isActive('relay')}
             isInPropagationPhase={isInPropagationPhase(currentTime, nodeBlockSeen, nodeBlockP2P)}
             subtitle={
-              winningBid
-                ? `via ${winningBid.relayName}`
-                : activeRelays > 0
-                  ? `${activeRelays} relay${activeRelays > 1 ? 's' : ''}`
-                  : 'Waiting for relays...'
+              winningBid?.deliveredRelays?.length
+                ? `Delivered by ${winningBid.deliveredRelays.join(', ')}`
+                : winningBid
+                  ? `via ${winningBid.relayName}`
+                  : activeRelays > 0
+                    ? `${activeRelays} relay${activeRelays > 1 ? 's' : ''}`
+                    : 'Waiting for relays...'
             }
           />
 

--- a/frontend/src/pages/beacon/block-production/live.tsx
+++ b/frontend/src/pages/beacon/block-production/live.tsx
@@ -577,7 +577,6 @@ export default function BlockProductionLivePage() {
 
     // If no matching bid was found but we have delivered payloads
     if (deliveredRelays.length > 0) {
-      console.info('No matching bid found, but we have delivered payloads for:', executionPayloadBlockHash);
       return {
         blockHash: executionPayloadBlockHash,
         value: 0,

--- a/frontend/src/pages/beacon/block-production/slot.tsx
+++ b/frontend/src/pages/beacon/block-production/slot.tsx
@@ -213,8 +213,7 @@ export default function BlockProductionSlotPage() {
 
     // If no matching bid was found but we have delivered payloads
     if (deliveredRelays.length > 0) {
-      console.info('No matching bid found, but we have delivered payloads for:', executionPayloadBlockHash);
-      return {
+        return {
         blockHash: executionPayloadBlockHash,
         value: 0,
         relayName: deliveredRelays[0], // Use the first relay as primary
@@ -222,7 +221,6 @@ export default function BlockProductionSlotPage() {
       };
     }
 
-    console.info('No matching bid or delivered payloads found for execution payload:', executionPayloadBlockHash);
     return null;
   }, [slotData?.relayBids, slotData?.block?.executionPayloadBlockHash, slotData?.deliveredPayloads]);
 


### PR DESCRIPTION
## Summary
- Fixes the logic for detecting winning relays in the block production view by checking both `relay_bids` and `delivered_payloads`
- Updates both desktop and mobile views to properly display all relays that delivered a payload
- Correctly handles cases where multiple relays delivered the same payload

## Test plan
- Check the MEV Relays section of the block production view to ensure all relays that delivered a payload are marked as "winning"
- For blocks with multiple relays that delivered the payload, all should be highlighted 
- The mobile view should now show "Delivered by Relay1, Relay2" when multiple relays delivered the payload

🤖 Generated with [Claude Code](https://claude.ai/code)