### PR TITLE
fix(build): create lab bucket in MinIO

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,9 +35,9 @@ services:
     entrypoint: >
       /bin/sh -c "
       sleep 5;
-      /usr/bin/mc config host add myminio http://minio:9000 minioadmin minioadmin;
+      /usr/bin/mc alias set myminio http://minio:9000 minioadmin minioadmin;
       /usr/bin/mc mb myminio/lab;
-      /usr/bin/mc policy set public myminio/lab;
+      /usr/bin/mc anonymous set public myminio/lab;
       exit 0;
       "
     profiles: 


### PR DESCRIPTION
## Description
Faced some errors when starting up the infra services on a freshly cloned repo, particular `minio`. It could be due to outdated commands.

## Example
Command: `docker-compose --profile infra up`

Expected Behaviour:
- No error messages

Actual Behaviour:
```
createbuckets-1  | 
createbuckets-1  | mc: <ERROR> `config` is not a recognized command. Get help using `--help` flag. 
createbuckets-1  | Bucket created successfully `myminio/lab`.
createbuckets-1  | mc: Please use 'mc anonymous'
createbuckets-1 exited with code 0
```

Applying the changes in this PR yield the following logs:
```
createbuckets-1  | Added `myminio` successfully.
createbuckets-1  | Bucket created successfully `myminio/lab`.
createbuckets-1  | Access permission for `myminio/lab` is set to `public`
createbuckets-1 exited with code 0
```