### PR TITLE
feat: introduce REST API v1 client and dual-URL configuration

### DIFF
--- a/backend/pkg/api/service.go
+++ b/backend/pkg/api/service.go
@@ -115,8 +115,6 @@ func (s *Service) Start(ctx context.Context) error {
 		}
 
 		prefix = strings.TrimSuffix(prefix, "/")
-
-		s.log.WithField("prefix", prefix).Info("Using path prefix")
 	}
 
 	// Register legacy HTTP handlers under the prefix
@@ -143,9 +141,10 @@ func (s *Service) Start(ctx context.Context) error {
 	// Mount the Connect handler at the correct path
 	// ConnectRPC handles routing from this base path to the specific endpoints
 	if prefix != "" {
-		// For prefixed paths: /lab-data/api/... -> handler
-		fullAPIPath := prefix + "/api"
-		s.log.WithField("apiPath", fullAPIPath).Info("Registering Connect handler")
+		s.log.WithFields(logrus.Fields{
+			"public_v1": "/api/v1/",
+			"connect":   prefix + "/api/",
+		}).Info("Registering handlers")
 
 		// Create a custom router that will dispatch to public API routes, Connect handler, or legacy router
 		customHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,7 +4,15 @@
 # This allows you to point the frontend to a different backend API endpoint
 # If not set, the frontend will use the Vite proxy configuration in development
 # or the bootstrap.json configuration in production
+# This URL is used for legacy endpoints (gRPC, static JSON files)
 VITE_BACKEND_URL=http://localhost:8080/lab-data
+
+# REST API v1 URL override
+# This is for the new v1 REST API endpoints (/api/v1/*)
+# If not set, will fall back to using VITE_BACKEND_URL (with /lab-data automatically stripped)
+# Example for production: https://lab-api.primary.production.platform.ethpandaops.io
+# Example for local development: http://localhost:8080
+VITE_REST_API_URL=http://localhost:8080
 
 # Node environment (development, production, test)
 # NODE_ENV=development

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -56,7 +56,24 @@ The development server will be available at http://localhost:5173 and will autom
 
 By default, the frontend connects to the backend API through a Vite proxy configuration. This allows you to run the frontend independently while still accessing backend data.
 
-To override the backend URL in development mode, set the `VITE_BACKEND_URL` environment variable in your `.env` file.
+The frontend supports two separate backend URLs:
+
+1. **Legacy Backend URL** (`VITE_BACKEND_URL`): Used for gRPC endpoints and static JSON files. This URL typically includes the `/lab-data` suffix.
+   ```
+   VITE_BACKEND_URL=https://lab-api.primary.production.platform.ethpandaops.io/lab-data
+   ```
+
+2. **REST API URL** (`VITE_REST_API_URL`): Used for new v1 REST API endpoints (`/api/v1/*`). This URL should NOT include the `/lab-data` suffix.
+   ```
+   VITE_REST_API_URL=https://lab-api.primary.production.platform.ethpandaops.io
+   ```
+
+If `VITE_REST_API_URL` is not set, the system will fall back to using `VITE_BACKEND_URL` (automatically stripping `/lab-data` if present).
+
+This dual-URL configuration allows you to:
+- Point to different servers for legacy and new endpoints
+- Gradually migrate from static data to REST APIs
+- Support different deployment scenarios
 
 ## Scripts
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -109,7 +109,7 @@ function App() {
     <ApplicationProvider
       network={{ selectedNetwork, availableNetworks }}
       config={{ config }}
-      api={{ client, baseUrl: bootstrap.backend.url }}
+      api={{ client, baseUrl: bootstrap.backend.url, restApiUrl: bootstrap.backend.restApiUrl }}
       beacon={{ config }}
     >
       <ModalProvider>

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,8 +1,34 @@
-// Export the singleton client
-export { getLabApiClient, resetLabApiClient } from '@/api/singleton.ts';
+// Export the singleton clients
+export {
+  getLabApiClient,
+  resetLabApiClient,
+  getRestApiClient,
+  resetRestApiClient,
+  resetAllClients,
+} from '@/api/singleton.ts';
 
 // Export the client creator for cases where a custom instance is needed
 export { createLabApiClient, type LabApiClient } from '@/api/client.ts';
 
+// Export REST client and types
+export { RestApiClient } from './rest/client';
+export type { NetworksParams, NodesParams } from './rest/client';
+export type { NodeFilters, NetworkFilters, FilterOperator } from './rest/endpoints';
+
 // Re-export the generated proto types for convenience
 export * from '@/api/gen/backend/pkg/api/proto/lab_api_pb';
+
+// Re-export protobuf types from v1 API for convenience
+export {
+  ListNodesResponse,
+  ListNetworksResponse,
+  Node,
+  Network,
+  ClientInfo,
+  GeoInfo,
+  ConsensusInfo,
+  PaginationMetadata,
+  FilterMetadata,
+  NetworkFilterMetadata,
+  ErrorResponse,
+} from './gen/backend/pkg/api/v1/proto/public_pb';

--- a/frontend/src/api/rest/client.ts
+++ b/frontend/src/api/rest/client.ts
@@ -1,0 +1,261 @@
+import {
+  ListNodesResponse,
+  ListNetworksResponse,
+  ErrorResponse,
+} from '../gen/backend/pkg/api/v1/proto/public_pb';
+import { API_V1_ENDPOINTS, buildQueryString, NodeFilters, NetworkFilters } from './endpoints';
+
+/**
+ * REST API client for v1 endpoints
+ *
+ * Note: The getNodes() method automatically filters for xatu public nodes
+ * (meta_client_name starting with 'pub-' or 'ethpandaops').
+ * Use getAllNodes() if you need to fetch all nodes without this filter.
+ */
+export class RestApiClient {
+  private baseUrl: string;
+  private maxRetries = 3;
+  private retryDelay = 1000; // milliseconds
+
+  constructor(baseUrl: string) {
+    // Remove trailing slash
+    let cleanUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+
+    // Remove /lab-data suffix if present (for backward compatibility)
+    // This handles the case where a dedicated REST API URL is not provided
+    if (cleanUrl.endsWith('/lab-data')) {
+      cleanUrl = cleanUrl.slice(0, -9); // Remove '/lab-data' (9 characters)
+      console.log('REST API Client: Removed /lab-data suffix from URL');
+    }
+
+    this.baseUrl = cleanUrl;
+    console.log('REST API Client initialized with base URL:', this.baseUrl);
+  }
+
+  /**
+   * Get list of available networks
+   * @param filters Optional filters for networks
+   * @returns ListNetworksResponse
+   */
+  async getNetworks(filters?: NetworkFilters): Promise<ListNetworksResponse> {
+    const queryString = filters ? buildQueryString(filters) : new URLSearchParams();
+    const url = `${this.baseUrl}${API_V1_ENDPOINTS.networks}${
+      queryString.toString() ? `?${queryString.toString()}` : ''
+    }`;
+
+    console.log('Fetching networks from:', url);
+    const response = await this.fetchWithRetry<any>(url);
+
+    // The REST API returns JSON that matches the protobuf message format
+    // Use fromJson to deserialize the JSON response into protobuf message instance
+    return ListNetworksResponse.fromJson(response);
+  }
+
+  /**
+   * Get list of xatu public nodes for a specific network
+   * Automatically filters for nodes with meta_client_name starting with 'pub-' or 'ethpandaops'
+   * @param network Network name
+   * @param filters Optional additional filters for nodes
+   * @returns ListNodesResponse with combined results from both filters
+   */
+  async getNodes(network: string, filters?: NodeFilters): Promise<ListNodesResponse> {
+    // Always add the meta_client_name filter for xatu public nodes
+    const baseFilters = { ...filters };
+
+    // Determine which prefix to use based on username filter
+    const username = filters?.username;
+    const isEthpandaopsUser =
+      (typeof username === 'string' && username === 'ethpandaops') ||
+      (typeof username === 'object' && 'eq' in username && username.eq === 'ethpandaops');
+
+    if (isEthpandaopsUser) {
+      // For ethpandaops user, only fetch nodes with ethpandaops prefix
+      const ethpandaopsFilters = {
+        ...baseFilters,
+        meta_client_name: { starts_with: 'ethpandaops' },
+      };
+      const queryString = buildQueryString(ethpandaopsFilters);
+      const url = `${this.baseUrl}${API_V1_ENDPOINTS.nodes(network)}${
+        queryString.toString() ? `?${queryString.toString()}` : ''
+      }`;
+
+      console.log('Fetching ethpandaops nodes from:', url);
+      const response = await this.fetchWithRetry<any>(url);
+      const nodes = ListNodesResponse.fromJson(response);
+      console.log(`Fetched ${nodes.nodes.length} ethpandaops nodes`);
+      return nodes;
+    } else if (username) {
+      // For other specific users, only fetch nodes with pub- prefix
+      const pubFilters = {
+        ...baseFilters,
+        meta_client_name: { starts_with: 'pub-' },
+      };
+      const queryString = buildQueryString(pubFilters);
+      const url = `${this.baseUrl}${API_V1_ENDPOINTS.nodes(network)}${
+        queryString.toString() ? `?${queryString.toString()}` : ''
+      }`;
+
+      console.log('Fetching pub- nodes from:', url);
+      const response = await this.fetchWithRetry<any>(url);
+      const nodes = ListNodesResponse.fromJson(response);
+      console.log(`Fetched ${nodes.nodes.length} pub- nodes`);
+      return nodes;
+    } else {
+      // For general queries (no specific user), fetch both pub- and ethpandaops nodes
+      // This is used for the main xatu page showing all nodes
+      const pubFilters = {
+        ...baseFilters,
+        meta_client_name: { starts_with: 'pub-' },
+      };
+      const pubQueryString = buildQueryString(pubFilters);
+      const pubUrl = `${this.baseUrl}${API_V1_ENDPOINTS.nodes(network)}${
+        pubQueryString.toString() ? `?${pubQueryString.toString()}` : ''
+      }`;
+
+      const ethpandaopsFilters = {
+        ...baseFilters,
+        meta_client_name: { starts_with: 'ethpandaops' },
+      };
+      const ethpandaopsQueryString = buildQueryString(ethpandaopsFilters);
+      const ethpandaopsUrl = `${this.baseUrl}${API_V1_ENDPOINTS.nodes(network)}${
+        ethpandaopsQueryString.toString() ? `?${ethpandaopsQueryString.toString()}` : ''
+      }`;
+
+      console.log('Fetching nodes with meta_client_name filters:');
+      console.log('  - pub- nodes from:', pubUrl);
+      console.log('  - ethpandaops nodes from:', ethpandaopsUrl);
+
+      // Execute both requests in parallel for better performance
+      const [pubResponse, ethpandaopsResponse] = await Promise.all([
+        this.fetchWithRetry<any>(pubUrl),
+        this.fetchWithRetry<any>(ethpandaopsUrl),
+      ]);
+
+      // Parse responses
+      const pubNodes = ListNodesResponse.fromJson(pubResponse);
+      const ethpandaopsNodes = ListNodesResponse.fromJson(ethpandaopsResponse);
+
+      // Combine the results
+      const combinedNodes = [...pubNodes.nodes, ...ethpandaopsNodes.nodes];
+
+      console.log(
+        `Fetched ${pubNodes.nodes.length} pub- nodes and ${ethpandaopsNodes.nodes.length} ethpandaops nodes (total: ${combinedNodes.length})`,
+      );
+
+      // Create a combined response
+      return new ListNodesResponse({
+        nodes: combinedNodes,
+        pagination: pubNodes.pagination, // Use pagination from first response
+        filters: pubNodes.filters,
+      });
+    }
+  }
+
+  /**
+   * Get list of ALL nodes for a specific network (without xatu public filter)
+   * Use this method when you need all nodes, not just xatu public nodes
+   * @param network Network name
+   * @param filters Optional filters for nodes
+   * @returns ListNodesResponse
+   */
+  async getAllNodes(network: string, filters?: NodeFilters): Promise<ListNodesResponse> {
+    const queryString = filters ? buildQueryString(filters) : new URLSearchParams();
+    const url = `${this.baseUrl}${API_V1_ENDPOINTS.nodes(network)}${
+      queryString.toString() ? `?${queryString.toString()}` : ''
+    }`;
+
+    console.log('Fetching ALL nodes from:', url);
+    const response = await this.fetchWithRetry<any>(url);
+
+    // The REST API returns JSON that matches the protobuf message format
+    // Use fromJson to deserialize the JSON response into protobuf message instance
+    return ListNodesResponse.fromJson(response);
+  }
+
+  /**
+   * Fetch with automatic retry on failure
+   * @param url URL to fetch
+   * @param options Fetch options
+   * @returns Response data
+   */
+  private async fetchWithRetry<T>(url: string, options?: RequestInit, retryCount = 0): Promise<T> {
+    try {
+      const response = await fetch(url, {
+        ...options,
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          ...options?.headers,
+        },
+      });
+
+      if (!response.ok) {
+        // Try to parse error response
+        let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+        try {
+          const errorData = await response.json();
+          const errorResponse = ErrorResponse.fromJson(errorData);
+          errorMessage = errorResponse.message || errorResponse.error || errorMessage;
+        } catch {
+          // If we can't parse the error, use the default message
+        }
+
+        // Retry on 5xx errors
+        if (response.status >= 500 && retryCount < this.maxRetries) {
+          await this.delay(this.retryDelay * Math.pow(2, retryCount)); // Exponential backoff
+          return this.fetchWithRetry<T>(url, options, retryCount + 1);
+        }
+
+        throw new Error(errorMessage);
+      }
+
+      return await response.json();
+    } catch (error) {
+      // Retry on network errors
+      if (retryCount < this.maxRetries && this.isNetworkError(error)) {
+        await this.delay(this.retryDelay * Math.pow(2, retryCount)); // Exponential backoff
+        return this.fetchWithRetry<T>(url, options, retryCount + 1);
+      }
+
+      throw error;
+    }
+  }
+
+  /**
+   * Check if error is a network error
+   * @param error Error to check
+   * @returns True if network error
+   */
+  private isNetworkError(error: any): boolean {
+    return (
+      error instanceof TypeError &&
+      (error.message.includes('Failed to fetch') ||
+        error.message.includes('NetworkError') ||
+        error.message.includes('ERR_NETWORK'))
+    );
+  }
+
+  /**
+   * Delay for a specified amount of time
+   * @param ms Milliseconds to delay
+   * @returns Promise that resolves after delay
+   */
+  private delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+}
+
+/**
+ * Parameters for getNetworks API call
+ */
+export interface NetworksParams extends NetworkFilters {}
+
+/**
+ * Parameters for getNodes API call
+ */
+export interface NodesParams extends NodeFilters {}
+
+/**
+ * Export the getAllNodes method type for external use
+ */
+export type GetAllNodesMethod = RestApiClient['getAllNodes'];

--- a/frontend/src/api/rest/endpoints.ts
+++ b/frontend/src/api/rest/endpoints.ts
@@ -1,0 +1,92 @@
+/**
+ * API endpoint configuration for REST API v1
+ */
+
+/**
+ * Build API v1 endpoint URLs
+ */
+export const API_V1_ENDPOINTS = {
+  networks: '/api/v1/networks',
+  nodes: (network: string) => `/api/v1/${network}/nodes`,
+};
+
+/**
+ * Build query string from parameters, supporting Stripe-style bracket notation for filters
+ * @param params Query parameters
+ * @returns URLSearchParams object
+ */
+export function buildQueryString(params: Record<string, any>): URLSearchParams {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null) return;
+
+    // Handle nested object filters (e.g., username: { eq: 'test' })
+    if (typeof value === 'object' && !Array.isArray(value)) {
+      Object.entries(value).forEach(([operator, operatorValue]) => {
+        if (operatorValue !== undefined && operatorValue !== null) {
+          // Use bracket notation for nested filters (e.g., username[eq]=test)
+          searchParams.append(`${key}[${operator}]`, String(operatorValue));
+        }
+      });
+    } else if (Array.isArray(value)) {
+      // Handle array values
+      value.forEach(item => {
+        searchParams.append(key, String(item));
+      });
+    } else {
+      // Handle simple values
+      searchParams.append(key, String(value));
+    }
+  });
+
+  return searchParams;
+}
+
+/**
+ * Filter operators for node queries
+ */
+export interface FilterOperator<T> {
+  eq?: T; // equals
+  neq?: T; // not equals
+  gt?: T; // greater than
+  gte?: T; // greater than or equal
+  lt?: T; // less than
+  lte?: T; // less than or equal
+  contains?: T; // contains (for strings)
+  starts_with?: T; // starts with (for strings)
+  ends_with?: T; // ends with (for strings)
+  in?: T[]; // in array
+  not_in?: T[]; // not in array
+}
+
+/**
+ * Node filter parameters using Stripe-style bracket notation
+ */
+export interface NodeFilters {
+  username?: string | FilterOperator<string>;
+  client_name?: string | FilterOperator<string>;
+  client_version?: string | FilterOperator<string>;
+  client_implementation?: string | FilterOperator<string>;
+  consensus_version?: string | FilterOperator<string>;
+  consensus_implementation?: string | FilterOperator<string>;
+  classification?: string | FilterOperator<string>;
+  city?: string | FilterOperator<string>;
+  country?: string | FilterOperator<string>;
+  country_code?: string | FilterOperator<string>;
+  continent_code?: string | FilterOperator<string>;
+  last_seen?: string | FilterOperator<string>;
+  meta_client_name?: string | FilterOperator<string>;
+  page_size?: number;
+  page_token?: string;
+  order_by?: string;
+}
+
+/**
+ * Network filter parameters
+ */
+export interface NetworkFilters {
+  active_only?: boolean;
+  status?: string | FilterOperator<string>;
+  chain_id?: number | FilterOperator<number>;
+}

--- a/frontend/src/api/rest/index.ts
+++ b/frontend/src/api/rest/index.ts
@@ -1,0 +1,12 @@
+/**
+ * REST API client exports
+ */
+
+export { RestApiClient, NetworksParams, NodesParams } from './client';
+export {
+  API_V1_ENDPOINTS,
+  buildQueryString,
+  FilterOperator,
+  NodeFilters,
+  NetworkFilters,
+} from './endpoints';

--- a/frontend/src/bootstrap.ts
+++ b/frontend/src/bootstrap.ts
@@ -1,19 +1,25 @@
 export interface Bootstrap {
   backend: {
     url: string;
+    restApiUrl?: string; // Optional separate URL for REST API v1
   };
 }
 
 const isDev = import.meta.env.DEV;
 const backendOverride = import.meta.env.VITE_BACKEND_URL;
+const restApiOverride = import.meta.env.VITE_REST_API_URL;
 
 export default async function fetchBootstrap(): Promise<Required<Bootstrap>> {
   // Allow overriding backend URL in dev mode
   if (isDev && backendOverride) {
     console.log('Using backend override:', backendOverride);
+    if (restApiOverride) {
+      console.log('Using REST API override:', restApiOverride);
+    }
     return {
       backend: {
         url: backendOverride,
+        restApiUrl: restApiOverride,
       },
     };
   }
@@ -23,6 +29,7 @@ export default async function fetchBootstrap(): Promise<Required<Bootstrap>> {
     return {
       backend: {
         url: '/lab-data',
+        restApiUrl: undefined,
       },
     };
   }

--- a/frontend/src/config/features.ts
+++ b/frontend/src/config/features.ts
@@ -1,0 +1,13 @@
+/**
+ * Feature flags for controlling API data sources
+ * These allow gradual migration from static JSON to REST API
+ */
+export const FEATURE_FLAGS = {
+  useRestApiForXatu: true, // Toggle xatu data source to use REST API
+  useRestApiForNetworks: false, // Toggle networks list to use REST API
+  useRestApiForContributors: false, // Toggle contributor data to use REST API
+};
+
+export function isFeatureEnabled(flag: keyof typeof FEATURE_FLAGS): boolean {
+  return FEATURE_FLAGS[flag];
+}

--- a/frontend/src/contexts/api.ts
+++ b/frontend/src/contexts/api.ts
@@ -1,5 +1,6 @@
-import { useContext as reactUseContext, createContext, useState } from 'react';
+import { useContext as reactUseContext, createContext, useState, useEffect } from 'react';
 import { LabApiClient } from '@/api/client.ts';
+import { RestApiClient } from '@/api/rest/client';
 
 export const Context = createContext<State | undefined>(undefined);
 
@@ -14,25 +15,61 @@ export default function useContext() {
 export interface State {
   client: LabApiClient;
   setClient: (client: LabApiClient) => void;
+  restClient: RestApiClient | null;
+  setRestClient: (client: RestApiClient | null) => void;
   baseUrl: string;
   setBaseUrl: (baseUrl: string) => void;
+  restApiUrl?: string;
+  setRestApiUrl: (url: string | undefined) => void;
+  isLoading: boolean;
+  error: Error | null;
 }
 
 export interface ValueProps {
   client: LabApiClient;
   baseUrl: string;
+  restApiUrl?: string;
 }
 
 export function useValue(props: ValueProps): State {
   const [client, setClient] = useState<LabApiClient>(props.client);
+  const [restClient, setRestClient] = useState<RestApiClient | null>(null);
   const [baseUrl, setBaseUrl] = useState<string>(
     props.baseUrl.endsWith('/') ? props.baseUrl : `${props.baseUrl}/`,
   );
+  const [restApiUrl, setRestApiUrl] = useState<string | undefined>(props.restApiUrl);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Initialize REST client when URLs are available
+  useEffect(() => {
+    const urlToUse = restApiUrl || baseUrl; // Use dedicated REST API URL if available
+
+    if (urlToUse && !restClient) {
+      try {
+        setIsLoading(true);
+        // Use the appropriate URL for REST API
+        const newRestClient = new RestApiClient(urlToUse.replace(/\/$/, ''));
+        setRestClient(newRestClient);
+        setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Failed to initialize REST client'));
+      } finally {
+        setIsLoading(false);
+      }
+    }
+  }, [baseUrl, restApiUrl, restClient]);
 
   return {
     client,
     setClient,
+    restClient,
+    setRestClient,
     baseUrl,
     setBaseUrl,
+    restApiUrl,
+    setRestApiUrl,
+    isLoading,
+    error,
   };
 }

--- a/frontend/src/hooks/api/index.ts
+++ b/frontend/src/hooks/api/index.ts
@@ -1,0 +1,6 @@
+/**
+ * API hooks exports
+ */
+
+export { useNetworks } from './useNetworks';
+export { useNodes, useAllNetworkNodes, useContributorNodes } from './useNodes';

--- a/frontend/src/hooks/api/useNetworks.ts
+++ b/frontend/src/hooks/api/useNetworks.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { getRestApiClient } from '@/api';
+
+/**
+ * Hook to fetch list of available networks from the REST API
+ * @param activeOnly - Whether to fetch only active networks
+ * @returns Query result with networks data, loading state, and error
+ */
+export function useNetworks(activeOnly?: boolean) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['networks', activeOnly],
+    queryFn: async () => {
+      const client = await getRestApiClient();
+      return client.getNetworks({ active_only: activeOnly });
+    },
+    staleTime: 1000 * 60 * 5, // Consider data fresh for 5 minutes
+  });
+
+  return {
+    networks: data?.networks,
+    isLoading,
+    error,
+  };
+}

--- a/frontend/src/hooks/api/useNodes.ts
+++ b/frontend/src/hooks/api/useNodes.ts
@@ -1,0 +1,71 @@
+import { useQuery } from '@tanstack/react-query';
+import { getRestApiClient, NodeFilters } from '@/api';
+import { transformNodesToUIFormat, aggregateNodesFromNetworks } from '@/utils/transformers';
+import useNetwork from '@/contexts/network';
+
+/**
+ * Hook to fetch nodes for a specific network
+ * @param network - Network name
+ * @param filters - Optional filters for nodes
+ * @returns Query result with transformed nodes data
+ */
+export function useNodes(network: string, filters?: NodeFilters) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['nodes', network, filters],
+    queryFn: async () => {
+      const client = await getRestApiClient();
+      const response = await client.getNodes(network, filters);
+      return transformNodesToUIFormat(response);
+    },
+    enabled: !!network,
+    staleTime: 1000 * 60 * 2, // Consider data fresh for 2 minutes
+  });
+
+  return {
+    nodes: data,
+    isLoading,
+    error,
+  };
+}
+
+/**
+ * Hook to fetch nodes from all available networks (parallel calls)
+ * @param filters - Optional filters for nodes
+ * @returns Query result with aggregated nodes from all networks
+ */
+export function useAllNetworkNodes(filters?: NodeFilters) {
+  const { availableNetworks } = useNetwork();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['nodes', 'all-networks', availableNetworks, filters],
+    queryFn: async () => {
+      const client = await getRestApiClient();
+      // Parallel fetch from all networks
+      const responses = await Promise.all(
+        availableNetworks.map(network => client.getNodes(network, filters)),
+      );
+      // Aggregate and transform all responses
+      return aggregateNodesFromNetworks(responses, availableNetworks);
+    },
+    enabled: availableNetworks.length > 0,
+    staleTime: 1000 * 60 * 2, // Consider data fresh for 2 minutes
+  });
+
+  return {
+    nodes: data,
+    isLoading,
+    error,
+  };
+}
+
+/**
+ * Hook to fetch nodes for a specific contributor/user from all networks
+ * @param username - Username to filter by
+ * @returns Query result with contributor's nodes from all networks
+ */
+export function useContributorNodes(username: string) {
+  // Fetch contributor's nodes from all networks
+  return useAllNetworkNodes({
+    username: { eq: username },
+  });
+}

--- a/frontend/src/pages/xatu/ContributorsList.tsx
+++ b/frontend/src/pages/xatu/ContributorsList.tsx
@@ -1,4 +1,4 @@
-import { useDataFetch } from '@/utils/data.ts';
+import { useDataFetch, useHybridDataFetch } from '@/utils/data.ts';
 import { LoadingState } from '@/components/common/LoadingState';
 import { ErrorState } from '@/components/common/ErrorState';
 import { Link } from 'react-router-dom';
@@ -7,6 +7,10 @@ import { formatDistanceToNow } from 'date-fns';
 import useConfig from '@/contexts/config';
 import { Card } from '@/components/common/Card';
 import useApi from '@/contexts/api';
+import useNetwork from '@/contexts/network';
+import { getRestApiClient } from '@/api';
+import { FEATURE_FLAGS } from '@/config/features';
+import { aggregateContributorSummary } from '@/utils/transformers';
 
 interface Contributor {
   name: string;
@@ -56,11 +60,31 @@ const formatTimestamp = (timestamp: number): string => {
 const ContributorsList = () => {
   const { config } = useConfig();
   const { baseUrl } = useApi();
+  const { selectedNetwork } = useNetwork();
   const summaryPath = config?.modules?.['xatuPublicContributors']?.pathPrefix
     ? `${config.modules['xatuPublicContributors'].pathPrefix}/user-summaries/summary.json`
     : null;
 
-  const { data: summaryData, loading, error } = useDataFetch<Summary>(baseUrl, summaryPath);
+  const {
+    data: summaryData,
+    loading,
+    error,
+  } = useHybridDataFetch<Summary>(
+    `${baseUrl}${summaryPath}`,
+    async () => {
+      const client = await getRestApiClient();
+      // When using REST API, only fetch nodes for the selected network (performance optimization)
+      const response = await client.getNodes(selectedNetwork);
+      // Aggregate nodes by username for selected network only
+      return aggregateContributorSummary(response.nodes);
+    },
+    FEATURE_FLAGS.useRestApiForXatu,
+    {
+      enabled: !!summaryPath || (FEATURE_FLAGS.useRestApiForXatu && !!selectedNetwork),
+      // Re-fetch when selected network changes
+      queryKey: ['contributors-summary', selectedNetwork, FEATURE_FLAGS.useRestApiForXatu],
+    },
+  );
 
   if (loading) {
     return <LoadingState />;

--- a/frontend/src/utils/transformers/index.ts
+++ b/frontend/src/utils/transformers/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Data transformation utilities exports
+ */
+
+export {
+  transformNodeToContributor,
+  aggregateNodesByCountry,
+  aggregateNodesByCity,
+  aggregateNodesByContinents,
+  aggregateNodesByClient,
+  aggregateNodesByUser,
+  aggregateNodesFromNetworks,
+  groupNodesByNetwork,
+  aggregateContributorSummary,
+  transformNodesToUIFormat,
+  deriveContinentFromCode,
+  type ContributorNode,
+  type CountryData,
+  type UserData,
+  type ConsensusImplementation,
+  type AggregatedNodes,
+  type ContributorSummary,
+  type NetworkData,
+} from './nodeTransformer';
+
+export {
+  transformNetworkResponse,
+  transformNodesResponse,
+  getActiveNetworks,
+  sortNetworksByPriority,
+  extractNetworkNames,
+  type NetworkSummary,
+  type TransformedNodes,
+} from './networkTransformer';

--- a/frontend/src/utils/transformers/networkTransformer.ts
+++ b/frontend/src/utils/transformers/networkTransformer.ts
@@ -1,0 +1,89 @@
+import {
+  Network,
+  ListNetworksResponse,
+  ListNodesResponse,
+} from '@/api/gen/backend/pkg/api/v1/proto/public_pb';
+
+/**
+ * Network summary structure
+ */
+export interface NetworkSummary {
+  name: string;
+  status: string;
+  chainId: string;
+  lastUpdated: string;
+  nodeCount?: number;
+}
+
+/**
+ * Transformed nodes structure
+ */
+export interface TransformedNodes {
+  nodes: any[];
+  totalCount: number;
+  pageSize: number;
+  nextPageToken?: string;
+}
+
+/**
+ * Transform a network response to summary format
+ */
+export function transformNetworkResponse(response: ListNetworksResponse): NetworkSummary[] {
+  return response.networks.map(network => ({
+    name: network.name,
+    status: network.status,
+    chainId: network.chainId.toString(),
+    lastUpdated: network.lastUpdated,
+    nodeCount: 0, // This would need to be fetched separately
+  }));
+}
+
+/**
+ * Transform nodes response to a simplified format
+ */
+export function transformNodesResponse(response: ListNodesResponse): TransformedNodes {
+  return {
+    nodes: response.nodes,
+    totalCount: response.nodes.length,
+    pageSize: response.pagination?.pageSize || 100,
+    nextPageToken: response.pagination?.nextPageToken,
+  };
+}
+
+/**
+ * Get active networks from a list
+ */
+export function getActiveNetworks(networks: Network[]): Network[] {
+  return networks.filter(network => network.status === 'active');
+}
+
+/**
+ * Sort networks by a standard order
+ */
+export function sortNetworksByPriority(networks: Network[]): Network[] {
+  const priority = ['mainnet', 'holesky', 'sepolia'];
+
+  return networks.sort((a, b) => {
+    const aIndex = priority.indexOf(a.name);
+    const bIndex = priority.indexOf(b.name);
+
+    // If both are in priority list, sort by priority
+    if (aIndex !== -1 && bIndex !== -1) {
+      return aIndex - bIndex;
+    }
+
+    // If only one is in priority list, it comes first
+    if (aIndex !== -1) return -1;
+    if (bIndex !== -1) return 1;
+
+    // Otherwise, sort alphabetically
+    return a.name.localeCompare(b.name);
+  });
+}
+
+/**
+ * Extract network names from response
+ */
+export function extractNetworkNames(response: ListNetworksResponse): string[] {
+  return response.networks.map(network => network.name);
+}

--- a/frontend/src/utils/transformers/nodeTransformer.ts
+++ b/frontend/src/utils/transformers/nodeTransformer.ts
@@ -1,0 +1,302 @@
+import { Node, ListNodesResponse } from '@/api/gen/backend/pkg/api/v1/proto/public_pb';
+
+/**
+ * ContributorNode structure used by the UI
+ */
+export interface ContributorNode {
+  network: string;
+  client_name: string;
+  consensus_client: string;
+  consensus_version: string;
+  country: string;
+  city: string;
+  continent: string;
+  latest_slot: number;
+  latest_slot_start_date_time: number;
+  client_implementation: string;
+  client_version: string;
+}
+
+/**
+ * Country data structure
+ */
+export interface CountryData {
+  name: string;
+  total_nodes: number;
+  public_nodes: number;
+}
+
+/**
+ * User/Contributor data structure
+ */
+export interface UserData {
+  name: string;
+  node_count: number;
+  updated_at: number;
+}
+
+/**
+ * Consensus implementation data
+ */
+export interface ConsensusImplementation {
+  total_nodes: number;
+  public_nodes: number;
+}
+
+/**
+ * Aggregated nodes structure
+ */
+export interface AggregatedNodes {
+  nodes: (Node & { network?: string })[];
+  byNetwork: Record<string, Node[]>;
+  totalCount: number;
+}
+
+/**
+ * Contributor summary structure
+ */
+export interface ContributorSummary {
+  contributors: UserData[];
+  updated_at: number;
+}
+
+/**
+ * Network data structure
+ */
+export interface NetworkData {
+  total_nodes: number;
+  total_public_nodes: number;
+  countries: Record<string, CountryData>;
+  continents: Record<string, CountryData>;
+  cities: Record<string, CountryData>;
+  consensus_implementations: Record<string, ConsensusImplementation>;
+}
+
+/**
+ * Derive continent name from continent code
+ */
+export function deriveContinentFromCode(continentCode?: string): string {
+  if (!continentCode) return '';
+
+  const continentMap: Record<string, string> = {
+    AF: 'Africa',
+    AN: 'Antarctica',
+    AS: 'Asia',
+    EU: 'Europe',
+    NA: 'North America',
+    OC: 'Oceania',
+    SA: 'South America',
+  };
+
+  return continentMap[continentCode] || continentCode;
+}
+
+/**
+ * Transform a Node to ContributorNode format
+ */
+export function transformNodeToContributor(node: Node, network?: string): ContributorNode {
+  return {
+    network: network || 'unknown',
+    client_name: node.client?.name || '',
+    consensus_client: node.consensus?.implementation || '',
+    consensus_version: node.consensus?.version || '',
+    country: node.geo?.country || '',
+    city: node.geo?.city || '',
+    continent: deriveContinentFromCode(node.geo?.continentCode),
+    latest_slot: 0, // This would need a separate endpoint or additional data
+    latest_slot_start_date_time: node.lastSeen ? new Date(node.lastSeen).getTime() / 1000 : 0,
+    client_implementation: node.client?.implementation || '',
+    client_version: node.client?.version || '',
+  };
+}
+
+/**
+ * Aggregate nodes by country
+ */
+export function aggregateNodesByCountry(nodes: Node[]): Record<string, CountryData> {
+  const countries: Record<string, CountryData> = {};
+
+  nodes.forEach(node => {
+    const country = node.geo?.country || 'Unknown';
+    if (!countries[country]) {
+      countries[country] = {
+        name: country,
+        total_nodes: 0,
+        public_nodes: 0,
+      };
+    }
+    countries[country].total_nodes++;
+    countries[country].public_nodes++; // All nodes from the API are public
+  });
+
+  return countries;
+}
+
+/**
+ * Aggregate nodes by city
+ */
+export function aggregateNodesByCity(nodes: Node[]): Record<string, CountryData> {
+  const cities: Record<string, CountryData> = {};
+
+  nodes.forEach(node => {
+    const city = node.geo?.city || 'Unknown';
+    if (!cities[city]) {
+      cities[city] = {
+        name: city,
+        total_nodes: 0,
+        public_nodes: 0,
+      };
+    }
+    cities[city].total_nodes++;
+    cities[city].public_nodes++; // All nodes from the API are public
+  });
+
+  return cities;
+}
+
+/**
+ * Aggregate nodes by continent
+ */
+export function aggregateNodesByContinents(nodes: Node[]): Record<string, CountryData> {
+  const continents: Record<string, CountryData> = {};
+
+  nodes.forEach(node => {
+    const continent = deriveContinentFromCode(node.geo?.continentCode) || 'Unknown';
+    if (!continents[continent]) {
+      continents[continent] = {
+        name: continent,
+        total_nodes: 0,
+        public_nodes: 0,
+      };
+    }
+    continents[continent].total_nodes++;
+    continents[continent].public_nodes++; // All nodes from the API are public
+  });
+
+  return continents;
+}
+
+/**
+ * Aggregate nodes by consensus client
+ */
+export function aggregateNodesByClient(nodes: Node[]): Record<string, ConsensusImplementation> {
+  const clients: Record<string, ConsensusImplementation> = {};
+
+  nodes.forEach(node => {
+    const client = node.consensus?.implementation || 'unknown';
+    if (!clients[client]) {
+      clients[client] = {
+        total_nodes: 0,
+        public_nodes: 0,
+      };
+    }
+    clients[client].total_nodes++;
+    clients[client].public_nodes++; // All nodes from the API are public
+  });
+
+  return clients;
+}
+
+/**
+ * Aggregate nodes by user/contributor
+ */
+export function aggregateNodesByUser(nodes: Node[]): UserData[] {
+  const userMap = new Map<string, UserData>();
+
+  nodes.forEach(node => {
+    const username = node.username || 'anonymous';
+    const existing = userMap.get(username) || {
+      name: username,
+      node_count: 0,
+      updated_at: 0,
+    };
+    existing.node_count++;
+    existing.updated_at = Math.max(
+      existing.updated_at,
+      node.lastSeen ? new Date(node.lastSeen).getTime() / 1000 : 0,
+    );
+    userMap.set(username, existing);
+  });
+
+  return Array.from(userMap.values());
+}
+
+/**
+ * Aggregate nodes from multiple network responses
+ */
+export function aggregateNodesFromNetworks(
+  responses: ListNodesResponse[],
+  networks: string[],
+): AggregatedNodes {
+  const allNodes: (Node & { network?: string })[] = [];
+  const byNetwork: Record<string, Node[]> = {};
+
+  responses.forEach((response, index) => {
+    const network = networks[index];
+    byNetwork[network] = response.nodes;
+
+    // Tag each node with its network for tracking
+    response.nodes.forEach(node => {
+      allNodes.push({ ...node, network });
+    });
+  });
+
+  return {
+    nodes: allNodes,
+    byNetwork,
+    totalCount: allNodes.length,
+  };
+}
+
+/**
+ * Group nodes by network
+ */
+export function groupNodesByNetwork(
+  nodes: (Node & { network?: string })[],
+): Record<string, Node[]> {
+  const grouped: Record<string, Node[]> = {};
+
+  nodes.forEach(node => {
+    const network = node.network || 'unknown';
+    if (!grouped[network]) {
+      grouped[network] = [];
+    }
+    grouped[network].push(node);
+  });
+
+  return grouped;
+}
+
+/**
+ * Build contributor summary from nodes
+ */
+export function aggregateContributorSummary(nodes: Node[]): ContributorSummary {
+  const userMap = new Map<string, UserData>();
+
+  nodes.forEach(node => {
+    const username = node.username || 'anonymous';
+    const existing = userMap.get(username) || {
+      name: username,
+      node_count: 0,
+      updated_at: 0,
+    };
+    existing.node_count++;
+    existing.updated_at = Math.max(
+      existing.updated_at,
+      node.lastSeen ? new Date(node.lastSeen).getTime() / 1000 : 0,
+    );
+    userMap.set(username, existing);
+  });
+
+  return {
+    contributors: Array.from(userMap.values()),
+    updated_at: Date.now() / 1000,
+  };
+}
+
+/**
+ * Transform nodes response to UI format
+ */
+export function transformNodesToUIFormat(response: ListNodesResponse): ContributorNode[] {
+  return response.nodes.map(node => transformNodeToContributor(node));
+}


### PR DESCRIPTION
Implements a new REST API client to fetch live node data, replacing static JSON files for improved performance and real-time updates. The integration uses feature flags to enable gradual migration while maintaining full backward compatibility.

- REST API Client: New client with automatic retry logic and error handling (frontend/src/api/rest/client.ts)
- Smart Filtering: Automatically filters xatu public nodes by meta_client_name prefix (pub- for users, ethpandaops for internal)
- Performance Optimization: Loads only selected network data instead of all networks, reducing API calls and improving load times
- Feature Flags: Configurable flags to control migration (`FEATURE_FLAGS.useRestApiForXatu`)
- Dual URL Support: Separate configuration for legacy (`VITE_BACKEND_URL`) and REST API (`VITE_REST_API_URL`) endpoints
- Hybrid Data Fetching: New utility hook that seamlessly switches between static JSON and REST API based on feature flags

- `/xatu` - Main dashboard
- `/xatu/contributors` - Contributors list
- `/xatu/contributors/{username}` - Individual contributor details

<img width="1840" height="880" alt="Screenshot 2025-09-08 at 2 49 36 pm" src="https://github.com/user-attachments/assets/5ae14b09-94a5-48dc-8c1a-cc916cfb7bac" />
