### PR TITLE
feat(frontend): add new xatu-data section with contributor pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,9 @@ import Redirect from '@/components/common/Redirect';
 import Home from '@/pages/Home.tsx';
 import { About } from '@/pages/About.tsx';
 import Xatu from '@/pages/xatu';
+import XatuData from '@/pages/xatu-data';
+import XatuDataContributorsList from '@/pages/xatu-data/ContributorsList';
+import XatuDataContributorDetail from '@/pages/xatu-data/ContributorDetail';
 import { CommunityNodes } from '@/pages/xatu/CommunityNodes';
 import Networks from '@/pages/xatu/networks';
 import ContributorsList from '@/pages/xatu/ContributorsList';
@@ -126,6 +129,10 @@ function App() {
               <Route path="contributors/:name" element={<ContributorDetail />} />
               <Route path="fork-readiness" element={<ForkReadiness />} />
               <Route path="geographical-checklist" element={<GeographicalChecklist />} />
+            </Route>
+            <Route path="xatu-data" element={<XatuData />}>
+              <Route path="contributors" element={<XatuDataContributorsList />} />
+              <Route path="contributors/:name" element={<XatuDataContributorDetail />} />
             </Route>
             <Route path="beacon" element={<Beacon />}>
               <Route path="slot" element={<Outlet />}>

--- a/frontend/src/api/rest/client.ts
+++ b/frontend/src/api/rest/client.ts
@@ -142,12 +142,17 @@ export class RestApiClient {
         `Fetched ${pubNodes.nodes.length} pub- nodes and ${ethpandaopsNodes.nodes.length} ethpandaops nodes (total: ${combinedNodes.length})`,
       );
 
-      // Create a combined response
-      return new ListNodesResponse({
+      // Create a combined response with public node count
+      const response = new ListNodesResponse({
         nodes: combinedNodes,
         pagination: pubNodes.pagination, // Use pagination from first response
         filters: pubNodes.filters,
       });
+
+      // Add public node count to response for easy access
+      (response as any).publicNodeCount = pubNodes.nodes.length;
+
+      return response;
     }
   }
 

--- a/frontend/src/pages/xatu-data/ContributorDetail.tsx
+++ b/frontend/src/pages/xatu-data/ContributorDetail.tsx
@@ -1,0 +1,277 @@
+import { useParams } from 'react-router-dom';
+import { LoadingState } from '@/components/common/LoadingState';
+import { ErrorState } from '@/components/common/ErrorState';
+import { formatDistanceToNow } from 'date-fns';
+import { XatuCallToAction } from '@/components/xatu/XatuCallToAction';
+import { NETWORK_METADATA, type NetworkKey } from '@/constants/networks.tsx';
+import { Card } from '@/components/common/Card';
+import useNetwork from '@/contexts/network';
+import { getRestApiClient } from '@/api';
+import { useQuery } from '@tanstack/react-query';
+import { transformNodeToContributor } from '@/utils/transformers';
+
+interface ContributorNode {
+  network: string;
+  client_name: string;
+  consensus_client: string;
+  consensus_version: string;
+  country: string;
+  city: string;
+  continent: string;
+  latest_slot: number;
+  latest_slot_start_date_time: number;
+  client_implementation: string;
+  client_version: string;
+}
+
+interface ContributorData {
+  name: string;
+  nodes: ContributorNode[];
+  updated_at: number;
+}
+
+type NetworkNodes = Record<string, ContributorNode[]>;
+
+const NETWORK_ORDER = ['mainnet', 'holesky', 'sepolia'];
+const OFFLINE_THRESHOLD = 3600; // 1 hour in seconds
+
+// Function to generate a deterministic color from a string
+const stringToColor = (str: string) => {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const hue = hash % 360;
+  return `hsl(${hue}, 70%, 60%)`;
+};
+
+// Function to generate initials from a string
+const getInitials = (name: string) => {
+  return name
+    .split(/[^a-zA-Z0-9]/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map(word => word[0])
+    .join('')
+    .toUpperCase();
+};
+
+function getShortNodeName(fullName: string): string {
+  const parts = fullName.split('/');
+  const lastPart = parts.at(-1) ?? '';
+  if (lastPart.startsWith('hashed-')) {
+    return lastPart.split('-').at(-1) ?? '';
+  }
+  return lastPart;
+}
+
+function capitalizeWords(input: string): string {
+  return input
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function isNodeOffline(node: ContributorNode, updatedAt: number): boolean {
+  return updatedAt - node.latest_slot_start_date_time > OFFLINE_THRESHOLD;
+}
+
+function ContributorDetail() {
+  const { name } = useParams<{ name: string }>();
+  const { selectedNetwork } = useNetwork();
+
+  // Fetch contributor data using REST API only - no conditionals!
+  const {
+    data: contributor,
+    isLoading,
+    error,
+  } = useQuery<ContributorData>({
+    queryKey: ['xatu-data-contributor', name, selectedNetwork],
+    queryFn: async () => {
+      const client = await getRestApiClient();
+      const response = await client.getNodes(selectedNetwork, {
+        username: { eq: name || '' },
+      });
+      // Transform nodes for selected network
+      const nodesWithNetwork = response.nodes.map(node =>
+        transformNodeToContributor(node, selectedNetwork),
+      );
+      return {
+        name: name || '',
+        nodes: nodesWithNetwork,
+        updated_at: Date.now() / 1000,
+      };
+    },
+    enabled: !!selectedNetwork && !!name,
+    staleTime: 30000, // Consider data fresh for 30 seconds
+    refetchInterval: 60000, // Refetch every minute
+  });
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (error) {
+    return <ErrorState message="Failed to load contributor data" />;
+  }
+
+  if (!contributor || !contributor.nodes || contributor.nodes.length === 0) {
+    return <ErrorState message="No data available for this contributor" />;
+  }
+
+  // Group nodes by network (in REST version, all nodes are from selected network)
+  const nodesByNetwork = contributor.nodes.reduce((accumulator: NetworkNodes, node) => {
+    if (!accumulator[node.network]) {
+      accumulator[node.network] = [];
+    }
+    accumulator[node.network].push(node);
+    return accumulator;
+  }, {});
+
+  // Sort networks based on NETWORK_ORDER
+  const sortedNetworks = Object.entries(nodesByNetwork).sort(([a], [b]) => {
+    const aIndex = NETWORK_ORDER.indexOf(a);
+    const bIndex = NETWORK_ORDER.indexOf(b);
+    if (aIndex === -1 && bIndex === -1) return a.localeCompare(b);
+    if (aIndex === -1) return 1;
+    if (bIndex === -1) return -1;
+    return aIndex - bIndex;
+  });
+
+  const avatarColor = stringToColor(contributor.name);
+  const initials = getInitials(contributor.name);
+
+  return (
+    <div className="space-y-8">
+      <XatuCallToAction />
+
+      {/* Contributor Overview */}
+      <Card className="card-primary">
+        <div className="card-body">
+          <div className="flex items-start gap-6">
+            <div
+              className="w-20 h-20 flex items-center justify-center text-2xl font-mono font-bold shadow-neon transition-transform hover:scale-105"
+              style={{
+                backgroundColor: avatarColor,
+                boxShadow: `0 0 20px ${avatarColor}10`,
+              }}
+            >
+              {initials}
+            </div>
+            <div className="flex-1">
+              <h1 className="text-2xl font-sans font-bold text-primary mb-2">{contributor.name}</h1>
+              <div className="text-sm font-mono text-tertiary mb-4">
+                Last updated{' '}
+                <span
+                  title={new Date(contributor.updated_at * 1000).toString()}
+                  className="text-primary cursor-help -b -prominent"
+                >
+                  {formatDistanceToNow(new Date(contributor.updated_at * 1000), {
+                    addSuffix: true,
+                  })}
+                </span>
+              </div>
+              <div className="flex flex-wrap gap-3">
+                {sortedNetworks.map(([network, nodes]) => {
+                  const metadata = NETWORK_METADATA[network as NetworkKey] || {
+                    name: network.charAt(0).toUpperCase() + network.slice(1),
+                    icon: '🔥',
+                  };
+                  return (
+                    <div
+                      key={network}
+                      className="flex items-center gap-2 card-secondary px-3 py-1.5 text-sm font-mono"
+                    >
+                      <span className="w-5 h-5 flex items-center justify-center">
+                        {metadata.icon}
+                      </span>
+                      <span className="text-primary/90">{metadata.name}</span>
+                      <span className="text-accent font-medium">{nodes.length} nodes</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+      </Card>
+
+      {/* Network Sections */}
+      <div className="space-y-8">
+        {sortedNetworks.map(([network, nodes]) => {
+          const metadata = NETWORK_METADATA[network as NetworkKey] || {
+            name: network.charAt(0).toUpperCase() + network.slice(1),
+            icon: '🔥',
+          };
+          return (
+            <section key={network} className="space-y-4">
+              <div className="flex items-center gap-3">
+                <div className="w-6 h-6 flex items-center justify-center">{metadata.icon}</div>
+                <h2 className="text-xl font-sans font-bold text-primary">{metadata.name}</h2>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {nodes.map(node => {
+                  const offline = isNodeOffline(node, contributor.updated_at);
+                  const shortName = getShortNodeName(node.client_name);
+                  return (
+                    <Card
+                      key={node.client_name}
+                      className={`card-secondary ${
+                        offline ? 'border-error/30 hover:border-error/50' : ''
+                      }`}
+                    >
+                      <div className="card-body">
+                        <div className="flex items-center gap-3 mb-4">
+                          <img
+                            src={`/clients/${node.consensus_client}.png`}
+                            alt={`${node.consensus_client} logo`}
+                            className="w-6 h-6 object-contain opacity-90"
+                            onError={e => {
+                              const target = e.currentTarget;
+                              target.style.display = 'none';
+                            }}
+                          />
+                          <div className="min-w-0">
+                            <div className="font-mono font-medium text-primary truncate">
+                              {shortName}
+                            </div>
+                            <div className="text-sm font-mono text-tertiary">
+                              {capitalizeWords(node.consensus_client)} ({node.consensus_version})
+                            </div>
+                          </div>
+                        </div>
+
+                        <div className="space-y-2 text-sm font-mono">
+                          <div className="flex justify-between">
+                            <span className="text-tertiary">Status</span>
+                            <span className={offline ? 'text-error' : 'text-primary'}>
+                              {offline ? 'Offline' : 'Online'}
+                            </span>
+                          </div>
+                          <div className="flex justify-between">
+                            <span className="text-tertiary">Location</span>
+                            <span className="text-primary/90">
+                              {[node.city, node.country, node.continent].filter(Boolean).join(', ')}
+                            </span>
+                          </div>
+                          <div className="flex justify-between">
+                            <span className="text-tertiary">Implementation</span>
+                            <span className="text-primary/90">
+                              {node.client_implementation} ({node.client_version})
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </Card>
+                  );
+                })}
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default ContributorDetail;

--- a/frontend/src/pages/xatu-data/ContributorsList.tsx
+++ b/frontend/src/pages/xatu-data/ContributorsList.tsx
@@ -1,0 +1,211 @@
+import { LoadingState } from '@/components/common/LoadingState';
+import { ErrorState } from '@/components/common/ErrorState';
+import { Link } from 'react-router-dom';
+import { XatuCallToAction } from '@/components/xatu/XatuCallToAction';
+import { formatDistanceToNow } from 'date-fns';
+import { Card } from '@/components/common/Card';
+import useNetwork from '@/contexts/network';
+import { getRestApiClient } from '@/api';
+import { useQuery } from '@tanstack/react-query';
+import { aggregateContributorSummary } from '@/utils/transformers';
+import { NetworkSelector } from '@/components/common/NetworkSelector';
+
+interface Contributor {
+  name: string;
+  node_count: number;
+  updated_at: number;
+}
+
+interface Summary {
+  contributors: Contributor[];
+  updated_at: number;
+}
+
+// Function to generate a deterministic color from a string
+const stringToColor = (str: string): string => {
+  let hash = 0;
+  for (let index = 0; index < str.length; index++) {
+    hash = (str.codePointAt(index) ?? 0) + ((hash << 5) - hash);
+  }
+  const hue = hash % 360;
+  return `hsl(${hue}, 70%, 60%)`;
+};
+
+// Function to generate initials from a string
+const getInitials = (name: string): string =>
+  name
+    .split(/[^\dA-Za-z]/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map(word => word[0])
+    .join('')
+    .toUpperCase();
+
+// Function to safely format a timestamp
+const formatTimestamp = (timestamp: number): string => {
+  try {
+    const date = new Date(timestamp * 1000);
+    // Check if the date is valid
+    if (isNaN(date.getTime())) {
+      return 'Invalid date';
+    }
+    return formatDistanceToNow(date, { addSuffix: true });
+  } catch (e) {
+    return 'Invalid date';
+  }
+};
+
+const ContributorsList = () => {
+  const { selectedNetwork, setSelectedNetwork } = useNetwork();
+
+  // Fetch contributors data using REST API only - no conditionals!
+  const {
+    data: summaryData,
+    isLoading,
+    error,
+  } = useQuery<Summary>({
+    queryKey: ['xatu-data-contributors', selectedNetwork],
+    queryFn: async () => {
+      const client = await getRestApiClient();
+      const response = await client.getNodes(selectedNetwork);
+      // Aggregate nodes by username for selected network
+      return aggregateContributorSummary(response.nodes);
+    },
+    enabled: !!selectedNetwork,
+    staleTime: 30000, // Consider data fresh for 30 seconds
+    refetchInterval: 60000, // Refetch every minute
+  });
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (error) {
+    return <ErrorState message="Failed to load contributors data" />;
+  }
+
+  if (!summaryData || !summaryData.contributors) {
+    return <ErrorState message="No data available" />;
+  }
+
+  return (
+    <div className="space-y-8">
+      <XatuCallToAction />
+
+      {/* About Section */}
+      <Card className="card-primary">
+        <div className="card-body">
+          <div className="flex flex-col">
+            <h2 className="text-xl font-sans font-bold text-primary mb-2">About</h2>
+            <p className="text-base font-mono text-secondary">
+              These are the amazing contributors who are helping us monitor the Ethereum network.
+              All data is anonymized and no personally identifiable information is collected.
+            </p>
+            <div className="text-sm font-mono text-tertiary mt-4">
+              Last updated{' '}
+              <span
+                title={new Date(summaryData.updated_at * 1000).toString()}
+                className="text-primary cursor-help -b -prominent"
+              >
+                {formatTimestamp(summaryData.updated_at)}
+              </span>
+              {' • '}
+              <span className="text-accent">{selectedNetwork}</span>
+            </div>
+          </div>
+        </div>
+      </Card>
+
+      {/* Contributors List */}
+      <Card className="card-primary">
+        <div className="card-header">
+          <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+            <div className="flex flex-col">
+              <h2 className="text-xl font-sans font-bold text-primary mb-2">Contributors</h2>
+              <p className="text-base font-mono text-secondary">
+                {summaryData.contributors.length} active contributors on {selectedNetwork}
+              </p>
+            </div>
+            <NetworkSelector
+              selectedNetwork={selectedNetwork}
+              onNetworkChange={network => setSelectedNetwork(network, 'ui')}
+              className="w-48"
+            />
+          </div>
+        </div>
+        <div className="card-body">
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+            {summaryData.contributors
+              .sort((a, b) => b.node_count - a.node_count)
+              .map((contributor, index) => {
+                const avatarColor = stringToColor(contributor.name);
+                const initials = getInitials(contributor.name);
+                const isRecent = Date.now() / 1000 - contributor.updated_at < 3600; // Active in last hour
+
+                return (
+                  <Link
+                    key={contributor.name}
+                    to={`/xatu-data/contributors/${contributor.name}`}
+                    className="block group"
+                  >
+                    <div className="relative bg-surface/20 hover:bg-surface/40 border border-subtle/30 hover:border-accent/40 rounded-xl p-5 transition-all duration-200 h-full overflow-hidden">
+                      {/* Gradient accent on hover */}
+                      <div
+                        className="absolute inset-x-0 top-0 h-px bg-gradient-to-r opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+                        style={{
+                          background: `linear-gradient(90deg, transparent, ${avatarColor}, transparent)`,
+                        }}
+                      />
+
+                      <div className="flex items-start gap-4">
+                        {/* Avatar with status */}
+                        <div className="relative">
+                          <div
+                            className="w-12 h-12 rounded-xl flex items-center justify-center text-sm font-mono font-bold text-white transition-transform group-hover:scale-105"
+                            style={{
+                              backgroundColor: avatarColor,
+                              boxShadow: `0 4px 12px ${avatarColor}40`,
+                            }}
+                          >
+                            {initials}
+                          </div>
+                          {isRecent && (
+                            <div className="absolute -top-1 -right-1 w-3 h-3 bg-green-500 rounded-full border-2 border-surface">
+                              <div className="w-full h-full bg-green-400 rounded-full animate-ping" />
+                            </div>
+                          )}
+                        </div>
+
+                        {/* Content */}
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center justify-between mb-1">
+                            <h3 className="font-mono text-primary group-hover:text-accent transition-colors truncate">
+                              {contributor.name}
+                            </h3>
+                            <div className="flex items-baseline gap-1">
+                              <span className="text-lg font-bold text-accent">
+                                {contributor.node_count}
+                              </span>
+                              <span className="text-xs text-tertiary">
+                                node{contributor.node_count !== 1 ? 's' : ''}
+                              </span>
+                            </div>
+                          </div>
+
+                          <div className="text-xs text-secondary">
+                            {formatTimestamp(contributor.updated_at)}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </Link>
+                );
+              })}
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default ContributorsList;

--- a/frontend/src/pages/xatu-data/index.tsx
+++ b/frontend/src/pages/xatu-data/index.tsx
@@ -1,0 +1,243 @@
+import { Link, Outlet, useLocation } from 'react-router-dom';
+import { ArrowRight } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import { useRef, useState, useEffect } from 'react';
+import { GlobeViz } from '@/components/xatu/GlobeViz';
+import { XatuCallToAction } from '@/components/xatu/XatuCallToAction';
+import useNetwork from '@/contexts/network';
+import { getRestApiClient } from '@/api';
+import { useQuery } from '@tanstack/react-query';
+import {
+  aggregateNodesByCountry,
+  aggregateNodesByCity,
+  aggregateNodesByContinents,
+  aggregateNodesByClient,
+} from '@/utils/transformers';
+import { NetworkSelector } from '@/components/common/NetworkSelector';
+
+const GLOBE_WIDTH = 500;
+const MS_PER_SECOND = 1000;
+
+const CLIENT_METADATA: Record<string, { name: string }> = {
+  prysm: { name: 'Prysm' },
+  teku: { name: 'Teku' },
+  lighthouse: { name: 'Lighthouse' },
+  lodestar: { name: 'Lodestar' },
+  nimbus: { name: 'Nimbus' },
+};
+
+function XatuData() {
+  const location = useLocation();
+  const containerReference = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const { selectedNetwork, setSelectedNetwork } = useNetwork();
+
+  // Fetch nodes data using REST API only - no conditionals!
+  const { data: networkData, isLoading } = useQuery({
+    queryKey: ['xatu-data-nodes', selectedNetwork],
+    queryFn: async () => {
+      const client = await getRestApiClient();
+      const response = await client.getNodes(selectedNetwork);
+      const nodes = response.nodes;
+
+      // Build aggregated data
+      // Public nodes count comes from the API response (nodes with pub- prefix)
+      const publicNodeCount = (response as any).publicNodeCount || 0;
+
+      return {
+        total_nodes: nodes.length,
+        total_public_nodes: publicNodeCount,
+        countries: aggregateNodesByCountry(nodes),
+        cities: aggregateNodesByCity(nodes),
+        continents: aggregateNodesByContinents(nodes),
+        consensus_implementations: aggregateNodesByClient(nodes),
+        updated_at: Date.now() / 1000,
+      };
+    },
+    enabled: !!selectedNetwork,
+    staleTime: 30000, // Consider data fresh for 30 seconds
+    refetchInterval: 60000, // Refetch every minute
+  });
+
+  useEffect(() => {
+    if (!containerReference.current) {
+      return;
+    }
+
+    setContainerWidth(containerReference.current.offsetWidth);
+
+    const observer = new ResizeObserver((entries: ResizeObserverEntry[]) => {
+      setContainerWidth(entries[0].contentRect.width);
+    });
+
+    observer.observe(containerReference.current);
+    return () => observer.disconnect();
+  }, []);
+
+  // If we're on a nested route, render the child route
+  if (location.pathname !== '/xatu-data') {
+    return (
+      <div>
+        <div>
+          <Outlet />
+        </div>
+      </div>
+    );
+  }
+
+  if (isLoading || !networkData) {
+    return <div>Loading live data...</div>;
+  }
+
+  // Transform data for the globe visualization
+  const globeData = [
+    {
+      time: Date.now() / MS_PER_SECOND,
+      countries: Object.entries(networkData.countries || {}).map(([name, data]) => ({
+        name,
+        value: data.total_nodes,
+      })),
+    },
+  ];
+
+  // Calculate client distribution
+  const clientDistribution = Object.entries(networkData.consensus_implementations || {})
+    .map(([client, data]) => ({
+      name: CLIENT_METADATA[client]?.name || client,
+      value: data.total_nodes,
+      publicValue: data.public_nodes,
+    }))
+    .sort((a, b) => b.value - a.value);
+
+  const totalCities = Object.keys(networkData.cities || {}).length;
+  const totalCountries = Object.keys(networkData.countries || {}).length;
+
+  return (
+    <div className="space-y-6 max-w-5xl mx-auto" ref={containerReference}>
+      <XatuCallToAction />
+
+      {/* Overview Header */}
+      <div className="bg-surface/50 backdrop-blur-sm rounded-lg border border-subtle p-4 shadow-sm">
+        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3">
+          <div>
+            <h2 className="text-xl font-sans font-bold text-primary">Xatu Network</h2>
+            <p className="text-xs font-mono text-secondary mt-1">
+              Last updated{' '}
+              {formatDistanceToNow(new Date(networkData.updated_at * MS_PER_SECOND), {
+                addSuffix: true,
+              })}
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="bg-surface/70 px-3 py-1.5 rounded border border-subtle/30">
+              <span className="text-xs font-mono text-accent">
+                {networkData.total_nodes.toLocaleString()} nodes • {selectedNetwork}
+              </span>
+            </div>
+            <NetworkSelector
+              selectedNetwork={selectedNetwork}
+              onNetworkChange={network => setSelectedNetwork(network, 'ui')}
+              className="w-48"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Globe and Key Stats */}
+        <div className="lg:col-span-2 bg-surface/50 rounded-lg border border-subtle p-4 shadow-sm">
+          <h3 className="text-sm font-sans font-medium text-primary mb-4">Global Distribution</h3>
+          <div className="flex justify-center">
+            <GlobeViz
+              data={globeData}
+              width={Math.min(containerWidth - 40, GLOBE_WIDTH)}
+              height={300}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mt-4">
+            <div>
+              <p className="text-xs font-mono text-tertiary">Total Nodes</p>
+              <p className="text-lg font-mono font-medium text-primary">
+                {networkData.total_nodes.toLocaleString()}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-mono text-tertiary">Public Nodes</p>
+              <p className="text-lg font-mono font-medium text-accent">
+                {networkData.total_public_nodes.toLocaleString()}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-mono text-tertiary">Countries</p>
+              <p className="text-lg font-mono font-medium text-primary">{totalCountries}</p>
+            </div>
+            <div>
+              <p className="text-xs font-mono text-tertiary">Cities</p>
+              <p className="text-lg font-mono font-medium text-primary">{totalCities}</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Client Distribution */}
+        <div className="bg-surface/50 rounded-lg border border-subtle p-4 shadow-sm">
+          <h3 className="text-sm font-sans font-medium text-primary mb-4">Client Distribution</h3>
+          <div className="space-y-3">
+            {clientDistribution.slice(0, 5).map(client => (
+              <div key={client.name} className="flex items-center gap-2">
+                <div className="w-5 h-5 rounded bg-surface/70 flex items-center justify-center">
+                  <img
+                    src={`/clients/${client.name.toLowerCase()}.png`}
+                    alt={`${client.name} logo`}
+                    className="w-3 h-3 object-contain"
+                    onError={event => {
+                      const target = event.currentTarget;
+                      target.style.display = 'none';
+                    }}
+                  />
+                </div>
+                <div className="flex-1 flex items-center justify-between">
+                  <span className="text-xs font-mono text-primary">{client.name}</span>
+                  <span className="text-xs font-mono text-accent">
+                    {networkData.total_nodes > 0
+                      ? ((client.value / networkData.total_nodes) * 100).toFixed(1)
+                      : '0.0'}
+                    %
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Navigation Links */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        {[
+          { to: 'contributors', emoji: '👥', title: 'Contributors' },
+          { to: 'networks', emoji: '🌐', title: 'Networks' },
+          { to: 'geographical-checklist', emoji: '🗺️', title: 'Geography' },
+          { to: 'fork-readiness', emoji: '🍴', title: 'Fork Readiness' },
+        ].map(item => (
+          <Link
+            key={item.to}
+            to={item.to}
+            className="bg-surface/50 hover:bg-surface/70 border border-subtle hover:border-accent/20 rounded-lg p-3 transition-all duration-200 flex items-center gap-2 group"
+          >
+            <div className="w-8 h-8 rounded bg-surface/70 flex items-center justify-center">
+              <span className="text-base">{item.emoji}</span>
+            </div>
+            <div className="flex-1">
+              <span className="text-sm font-sans font-medium text-primary group-hover:text-accent transition-colors">
+                {item.title}
+              </span>
+            </div>
+            <ArrowRight className="w-4 h-4 text-tertiary group-hover:text-accent group-hover:translate-x-1 transition-all duration-300" />
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default XatuData;

--- a/frontend/src/pages/xatu/ContributorsList.tsx
+++ b/frontend/src/pages/xatu/ContributorsList.tsx
@@ -138,57 +138,57 @@ const ContributorsList = () => {
           <div className="overflow-x-auto -mx-2">
             <table className="w-full min-w-[300px]">
               <thead>
-                <tr className="-b -subtle">
-                  <th className="text-left py-2 px-2 text-sm font-mono text-tertiary w-[60%]">
-                    Contributor
-                  </th>
-                  <th className="text-right py-2 px-2 text-sm font-mono text-tertiary w-[20%]">
-                    Nodes
-                  </th>
-                  <th className="text-right py-2 px-2 text-sm font-mono text-tertiary hidden sm:table-cell w-[20%]">
-                    Last Update
-                  </th>
-                </tr>
+              <tr className="-b -subtle">
+                <th className="text-left py-2 px-2 text-sm font-mono text-tertiary w-[60%]">
+                  Contributor
+                </th>
+                <th className="text-right py-2 px-2 text-sm font-mono text-tertiary w-[20%]">
+                  Nodes
+                </th>
+                <th className="text-right py-2 px-2 text-sm font-mono text-tertiary hidden sm:table-cell w-[20%]">
+                  Last Update
+                </th>
+              </tr>
               </thead>
               <tbody>
-                {summaryData.contributors
-                  .sort((a, b) => b.node_count - a.node_count)
-                  .map(contributor => {
-                    const avatarColor = stringToColor(contributor.name);
-                    const initials = getInitials(contributor.name);
-                    return (
-                      <tr
-                        key={contributor.name}
-                        className="-b -subtle hover:bg-hover transition-colors"
-                      >
-                        <td className="py-2 px-2 w-[60%]">
-                          <Link
-                            to={`/xatu/contributors/${contributor.name}`}
-                            className="flex items-center gap-2 hover:opacity-80 transition-opacity"
+              {summaryData.contributors
+                .sort((a, b) => b.node_count - a.node_count)
+                .map(contributor => {
+                  const avatarColor = stringToColor(contributor.name);
+                  const initials = getInitials(contributor.name);
+                  return (
+                    <tr
+                      key={contributor.name}
+                      className="-b -subtle hover:bg-hover transition-colors"
+                    >
+                      <td className="py-2 px-2 w-[60%]">
+                        <Link
+                          to={`/xatu/contributors/${contributor.name}`}
+                          className="flex items-center gap-2 hover:opacity-80 transition-opacity"
+                        >
+                          <div
+                            className="w-6 h-6 flex items-center justify-center text-xs font-mono font-bold shadow-neon transition-transform hover:scale-105"
+                            style={{
+                              backgroundColor: avatarColor,
+                              boxShadow: `0 0 10px ${avatarColor}05`,
+                            }}
                           >
-                            <div
-                              className="w-6 h-6 flex items-center justify-center text-xs font-mono font-bold shadow-neon transition-transform hover:scale-105"
-                              style={{
-                                backgroundColor: avatarColor,
-                                boxShadow: `0 0 10px ${avatarColor}05`,
-                              }}
-                            >
-                              {initials}
-                            </div>
-                            <span className="text-sm font-mono text-primary truncate">
+                            {initials}
+                          </div>
+                          <span className="text-sm font-mono text-primary truncate">
                               {contributor.name}
                             </span>
-                          </Link>
-                        </td>
-                        <td className="text-right py-2 px-2 text-sm font-mono text-primary w-[20%]">
-                          {contributor.node_count}
-                        </td>
-                        <td className="text-right py-2 px-2 text-sm font-mono text-tertiary hidden sm:table-cell w-[20%]">
-                          {formatTimestamp(contributor.updated_at)}
-                        </td>
-                      </tr>
-                    );
-                  })}
+                        </Link>
+                      </td>
+                      <td className="text-right py-2 px-2 text-sm font-mono text-primary w-[20%]">
+                        {contributor.node_count}
+                      </td>
+                      <td className="text-right py-2 px-2 text-sm font-mono text-tertiary hidden sm:table-cell w-[20%]">
+                        {formatTimestamp(contributor.updated_at)}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/frontend/src/pages/xatu/networks/index.tsx
+++ b/frontend/src/pages/xatu/networks/index.tsx
@@ -256,56 +256,56 @@ export default function Networks() {
                     <div className="overflow-x-auto rounded border border-subtle/30">
                       <table className="w-full text-xs font-mono border-collapse">
                         <thead className="bg-surface/70">
-                          <tr className="text-2xs text-tertiary">
-                            <th className="text-left font-normal p-2 pr-4 border-b border-subtle/30">
-                              Client
-                            </th>
-                            <th className="text-left font-normal p-2 border-b border-subtle/30 w-full">
-                              Distribution
-                            </th>
-                            <th className="text-right font-normal p-2 pl-4 border-b border-subtle/30">
-                              Share
-                            </th>
-                            <th className="text-right font-normal p-2 pl-4 border-b border-subtle/30">
-                              Total
-                            </th>
-                            <th className="text-right font-normal p-2 pl-4 border-b border-subtle/30">
-                              Community
-                            </th>
-                          </tr>
+                        <tr className="text-2xs text-tertiary">
+                          <th className="text-left font-normal p-2 pr-4 border-b border-subtle/30">
+                            Client
+                          </th>
+                          <th className="text-left font-normal p-2 border-b border-subtle/30 w-full">
+                            Distribution
+                          </th>
+                          <th className="text-right font-normal p-2 pl-4 border-b border-subtle/30">
+                            Share
+                          </th>
+                          <th className="text-right font-normal p-2 pl-4 border-b border-subtle/30">
+                            Total
+                          </th>
+                          <th className="text-right font-normal p-2 pl-4 border-b border-subtle/30">
+                            Community
+                          </th>
+                        </tr>
                         </thead>
                         <tbody>
-                          {displayedClients.map((client, index) => {
-                            const percentage =
-                              totalNodes > 0 ? (client.value / totalNodes) * 100 : 0;
-                            const isLastRow = index === displayedClients.length - 1;
+                        {displayedClients.map((client, index) => {
+                          const percentage =
+                            totalNodes > 0 ? (client.value / totalNodes) * 100 : 0;
+                          const isLastRow = index === displayedClients.length - 1;
 
-                            return (
-                              <tr
-                                key={client.name}
-                                className={`align-middle hover:bg-surface/50 ${!isLastRow ? 'border-b border-subtle/20' : ''}`}
-                              >
-                                <td className="p-2 pr-4 font-medium text-primary">{client.name}</td>
-                                <td className="p-2">
-                                  <div className="w-full h-2 bg-surface/70 rounded-full overflow-hidden">
-                                    <div
-                                      className="h-full bg-accent"
-                                      style={{ width: `${percentage}%` }}
-                                    />
-                                  </div>
-                                </td>
-                                <td className="text-right p-2 pl-4 text-accent whitespace-nowrap">
-                                  {percentage.toFixed(1)}%
-                                </td>
-                                <td className="text-right p-2 pl-4 text-tertiary whitespace-nowrap">
-                                  {client.value.toLocaleString()}
-                                </td>
-                                <td className="text-right p-2 pl-4 text-secondary whitespace-nowrap">
-                                  {client.publicValue.toLocaleString()}
-                                </td>
-                              </tr>
-                            );
-                          })}
+                          return (
+                            <tr
+                              key={client.name}
+                              className={`align-middle hover:bg-surface/50 ${!isLastRow ? 'border-b border-subtle/20' : ''}`}
+                            >
+                              <td className="p-2 pr-4 font-medium text-primary">{client.name}</td>
+                              <td className="p-2">
+                                <div className="w-full h-2 bg-surface/70 rounded-full overflow-hidden">
+                                  <div
+                                    className="h-full bg-accent"
+                                    style={{ width: `${percentage}%` }}
+                                  />
+                                </div>
+                              </td>
+                              <td className="text-right p-2 pl-4 text-accent whitespace-nowrap">
+                                {percentage.toFixed(1)}%
+                              </td>
+                              <td className="text-right p-2 pl-4 text-tertiary whitespace-nowrap">
+                                {client.value.toLocaleString()}
+                              </td>
+                              <td className="text-right p-2 pl-4 text-secondary whitespace-nowrap">
+                                {client.publicValue.toLocaleString()}
+                              </td>
+                            </tr>
+                          );
+                        })}
                         </tbody>
                       </table>
                     </div>


### PR DESCRIPTION
- This change keeps the old `/xatu` pages intact and introduce a dedicated `/xatu-data` route that uses the REST client. 
- This keeps old/new seperated and allows for easier migration to new endpoints rather than riddling the codebase with conditionals.
- With the aim of cbt data powering the lab, these xatu-data views are now network/context specific. Previously, even if "Mainnet" was selected in the header, they would show data relating to "All networks". As we'll likely be introducing devnet support these views/metrics are now network specific under the new `/xatu-data` views.

<img width="1336" height="878" alt="Screenshot 2025-09-09 at 8 44 51 am" src="https://github.com/user-attachments/assets/fb4bb87b-4a48-4090-a138-458d0898e6c4" />

<img width="1337" height="878" alt="Screenshot 2025-09-09 at 8 44 59 am" src="https://github.com/user-attachments/assets/b4f8f348-7233-4e46-8231-87d0ceddca25" />
