### PR TITLE
refactor: remove XatuCallToAction from all xatu pages and extend alert paths

### DIFF
--- a/frontend/src/components/common/SystemAlert.tsx
+++ b/frontend/src/components/common/SystemAlert.tsx
@@ -13,13 +13,13 @@ export const SystemAlert = ({
   title,
   buttonText,
   buttonLink,
-  showOnPaths = ['/beacon']
+  showOnPaths = ['/beacon'],
 }: SystemAlertProps) => {
   const location = useLocation();
-  
+
   // Check if current path starts with any of the paths in showOnPaths
   const shouldShow = showOnPaths.some(path => location.pathname.startsWith(path));
-  
+
   if (!shouldShow) {
     return null;
   }
@@ -48,7 +48,10 @@ export const SystemAlert = ({
 // Custom component with special styling for the Xatu contribution alert
 export const GoogleFormSystemAlert = () => {
   const location = useLocation();
-  const shouldShow = location.pathname.startsWith('/beacon');
+  const shouldShow =
+    location.pathname.startsWith('/beacon') ||
+    location.pathname.startsWith('/xatu') ||
+    location.pathname.startsWith('/xatu-data');
 
   if (!shouldShow) {
     return null;
@@ -58,7 +61,9 @@ export const GoogleFormSystemAlert = () => {
     <div className="flex items-center gap-2">
       <Database className="hidden xl:block h-4 w-4 text-accent" />
       <div className="flex-1 min-w-0 hidden xl:block">
-        <p className="text-xs font-medium text-primary whitespace-nowrap">Add your node to The Lab</p>
+        <p className="text-xs font-medium text-primary whitespace-nowrap">
+          Add your node to The Lab
+        </p>
       </div>
       <a
         href="https://ethpandaops.io/contribute-data/"

--- a/frontend/src/pages/xatu-data/ContributorDetail.tsx
+++ b/frontend/src/pages/xatu-data/ContributorDetail.tsx
@@ -2,7 +2,6 @@ import { useParams } from 'react-router-dom';
 import { LoadingState } from '@/components/common/LoadingState';
 import { ErrorState } from '@/components/common/ErrorState';
 import { formatDistanceToNow } from 'date-fns';
-import { XatuCallToAction } from '@/components/xatu/XatuCallToAction';
 import { NETWORK_METADATA, type NetworkKey } from '@/constants/networks.tsx';
 import { Card } from '@/components/common/Card';
 import useNetwork from '@/contexts/network';
@@ -144,7 +143,6 @@ function ContributorDetail() {
 
   return (
     <div className="space-y-8">
-      <XatuCallToAction />
 
       {/* Contributor Overview */}
       <Card className="relative z-10 card-primary overflow-visible">

--- a/frontend/src/pages/xatu-data/ContributorsList.tsx
+++ b/frontend/src/pages/xatu-data/ContributorsList.tsx
@@ -1,7 +1,6 @@
 import { LoadingState } from '@/components/common/LoadingState';
 import { ErrorState } from '@/components/common/ErrorState';
 import { Link } from 'react-router-dom';
-import { XatuCallToAction } from '@/components/xatu/XatuCallToAction';
 import { formatDistanceToNow } from 'date-fns';
 import { Card } from '@/components/common/Card';
 import useNetwork from '@/contexts/network';
@@ -90,7 +89,6 @@ const ContributorsList = () => {
 
   return (
     <div className="space-y-8">
-      <XatuCallToAction />
 
       {/* About Section */}
       <Card className="card-primary">

--- a/frontend/src/pages/xatu-data/fork-readiness/index.tsx
+++ b/frontend/src/pages/xatu-data/fork-readiness/index.tsx
@@ -6,7 +6,6 @@ import { formatNodeName } from '@/utils/format.ts';
 import { Card, CardHeader, CardBody } from '@/components/common/Card';
 import { LoadingState } from '@/components/common/LoadingState';
 import { ErrorState } from '@/components/common/ErrorState';
-import { XatuCallToAction } from '@/components/xatu/XatuCallToAction';
 import useNetwork from '@/contexts/network';
 import useConfig from '@/contexts/config';
 import { getRestApiClient } from '@/api';
@@ -158,7 +157,6 @@ function ForkReadiness() {
   if (!config?.ethereum?.networks[selectedNetwork]?.forks?.consensus?.electra) {
     return (
       <div className="space-y-6">
-        <XatuCallToAction />
 
         <Card className="relative z-10 card-primary overflow-visible">
           <CardBody className="flex flex-col items-center justify-center py-12 text-center">
@@ -184,7 +182,6 @@ function ForkReadiness() {
 
   return (
     <div className="space-y-6">
-      <XatuCallToAction />
 
       <Card className="relative z-10 card-primary overflow-visible">
         <CardHeader>

--- a/frontend/src/pages/xatu-data/geographical-checklist/index.tsx
+++ b/frontend/src/pages/xatu-data/geographical-checklist/index.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react';
 import useNetwork from '@/contexts/network';
 import { LoadingState } from '@/components/common/LoadingState';
 import { ErrorState } from '@/components/common/ErrorState';
-import { XatuCallToAction } from '@/components/xatu/XatuCallToAction';
 import { formatDistanceToNow } from 'date-fns';
 import { NetworkSelector } from '@/components/common/NetworkSelector';
 import { Search, ChevronDown, ChevronUp, Check, Globe, MapPin, Users } from 'lucide-react';
@@ -258,7 +257,6 @@ const GeographicalChecklist = () => {
 
   return (
     <div className="space-y-6 max-w-5xl mx-auto">
-      <XatuCallToAction />
 
       {/* Header */}
       <div className="relative z-10 bg-surface/50 backdrop-blur-sm rounded-lg border border-subtle p-4 shadow-sm overflow-visible">

--- a/frontend/src/pages/xatu-data/index.tsx
+++ b/frontend/src/pages/xatu-data/index.tsx
@@ -3,7 +3,6 @@ import { ArrowRight } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { useRef, useState, useEffect } from 'react';
 import { GlobeViz } from '@/components/xatu/GlobeViz';
-import { XatuCallToAction } from '@/components/xatu/XatuCallToAction';
 import useNetwork from '@/contexts/network';
 import { getRestApiClient } from '@/api';
 import { useQuery } from '@tanstack/react-query';
@@ -126,7 +125,6 @@ function XatuData() {
 
   return (
     <div className="space-y-6 max-w-5xl mx-auto" ref={containerReference}>
-      <XatuCallToAction />
 
       {/* Overview Header */}
       <div className="relative z-10 bg-surface/50 backdrop-blur-sm rounded-lg border border-subtle p-4 shadow-sm overflow-visible">

--- a/frontend/src/pages/xatu-data/networks/index.tsx
+++ b/frontend/src/pages/xatu-data/networks/index.tsx
@@ -1,5 +1,4 @@
 import { formatDistanceToNow } from 'date-fns';
-import { XatuCallToAction } from '@/components/xatu/XatuCallToAction';
 import { NETWORK_METADATA, type NetworkKey } from '@/constants/networks.tsx';
 import { LoadingState } from '@/components/common/LoadingState';
 import { ErrorState } from '@/components/common/ErrorState';
@@ -107,7 +106,6 @@ export default function Networks() {
 
   return (
     <div className="space-y-6 max-w-5xl mx-auto">
-      <XatuCallToAction />
 
       {/* Page Header */}
       <div className="relative z-10 bg-surface/50 backdrop-blur-sm rounded-lg border border-subtle p-4 shadow-sm overflow-visible">

--- a/frontend/src/pages/xatu/CommunityNodes.tsx
+++ b/frontend/src/pages/xatu/CommunityNodes.tsx
@@ -1,7 +1,6 @@
 import { useDataFetch } from '@/utils/data.ts';
 import { LoadingState } from '@/components/common/LoadingState';
 import { ErrorState } from '@/components/common/ErrorState';
-import { XatuCallToAction } from '@/components/xatu/XatuCallToAction';
 import { NetworkSelector } from '@/components/common/NetworkSelector';
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
@@ -335,7 +334,6 @@ export const CommunityNodes = () => {
           opacity: 0.5;
         }
       `}</style>
-      <XatuCallToAction />
 
       <div className="space-y-6">
         <AboutThisData>

--- a/frontend/src/pages/xatu/ContributorDetail.tsx
+++ b/frontend/src/pages/xatu/ContributorDetail.tsx
@@ -3,7 +3,6 @@ import { useDataFetch } from '@/utils/data.ts';
 import { LoadingState } from '@/components/common/LoadingState';
 import { ErrorState } from '@/components/common/ErrorState';
 import { formatDistanceToNow } from 'date-fns';
-import { XatuCallToAction } from '@/components/xatu/XatuCallToAction';
 import useConfig from '@/contexts/config';
 import { NETWORK_METADATA, type NetworkKey } from '@/constants/networks.tsx';
 import { Card } from '@/components/common/Card';
@@ -121,7 +120,6 @@ function ContributorDetail() {
 
   return (
     <div className="space-y-8">
-      <XatuCallToAction />
 
       {/* Contributor Overview */}
       <Card className="card-primary">

--- a/frontend/src/pages/xatu/Contributors.tsx
+++ b/frontend/src/pages/xatu/Contributors.tsx
@@ -1,7 +1,6 @@
 import { useDataFetch } from '@/utils/data.ts';
 import { LoadingState } from '@/components/common/LoadingState';
 import { ErrorState } from '@/components/common/ErrorState';
-import { XatuCallToAction } from '@/components/xatu/XatuCallToAction';
 import { NetworkSelector } from '@/components/common/NetworkSelector';
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
@@ -240,7 +239,6 @@ export const CommunityNodes = () => {
 
   return (
     <div className="space-y-8" ref={containerRef}>
-      <XatuCallToAction />
 
       <div className="backdrop-blur-md  p-6  shadow-xl mb-8">
         <h2 className="text-xl font-semibold text-accent mb-2">About This Data</h2>

--- a/frontend/src/pages/xatu/ContributorsList.tsx
+++ b/frontend/src/pages/xatu/ContributorsList.tsx
@@ -2,7 +2,6 @@ import { useDataFetch } from '@/utils/data.ts';
 import { LoadingState } from '@/components/common/LoadingState';
 import { ErrorState } from '@/components/common/ErrorState';
 import { Link } from 'react-router-dom';
-import { XatuCallToAction } from '@/components/xatu/XatuCallToAction';
 import { formatDistanceToNow } from 'date-fns';
 import useConfig from '@/contexts/config';
 import { Card } from '@/components/common/Card';
@@ -76,7 +75,6 @@ const ContributorsList = () => {
 
   return (
     <div className="space-y-8">
-      <XatuCallToAction />
 
       {/* About Section */}
       <Card className="card-primary">

--- a/frontend/src/pages/xatu/GeographicalChecklist.tsx
+++ b/frontend/src/pages/xatu/GeographicalChecklist.tsx
@@ -4,7 +4,6 @@ import useConfig from '@/contexts/config';
 import useNetwork from '@/contexts/network';
 import { LoadingState } from '@/components/common/LoadingState';
 import { ErrorState } from '@/components/common/ErrorState';
-import { XatuCallToAction } from '@/components/xatu/XatuCallToAction';
 import { formatDistanceToNow } from 'date-fns';
 import { NetworkSelector } from '@/components/common/NetworkSelector';
 import { Search, ChevronDown, ChevronUp, Check } from 'lucide-react';
@@ -228,7 +227,6 @@ const GeographicalChecklist = () => {
 
   return (
     <div className="space-y-6 max-w-5xl mx-auto">
-      <XatuCallToAction />
 
       {/* Header */}
       <div className="bg-surface/50 backdrop-blur-sm rounded-lg border border-subtle p-4 shadow-sm">

--- a/frontend/src/pages/xatu/index.tsx
+++ b/frontend/src/pages/xatu/index.tsx
@@ -4,7 +4,6 @@ import { useDataFetch } from '@/utils/data.ts';
 import { formatDistanceToNow } from 'date-fns';
 import { useRef, useState, useEffect } from 'react';
 import { GlobeViz } from '@/components/xatu/GlobeViz';
-import { XatuCallToAction } from '@/components/xatu/XatuCallToAction';
 import useConfig from '@/contexts/config';
 import useApi from '@/contexts/api';
 
@@ -127,8 +126,6 @@ function Xatu() {
 
   return (
     <div className="space-y-6 max-w-5xl mx-auto" ref={containerReference}>
-      <XatuCallToAction />
-
       {/* Overview Header */}
       <div className="bg-surface/50 backdrop-blur-sm rounded-lg border border-subtle p-4 shadow-sm">
         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3">

--- a/frontend/src/pages/xatu/networks/index.tsx
+++ b/frontend/src/pages/xatu/networks/index.tsx
@@ -1,6 +1,5 @@
 import { useDataFetch } from '@/utils/data.ts';
 import { formatDistanceToNow } from 'date-fns';
-import { XatuCallToAction } from '@/components/xatu/XatuCallToAction';
 import { useEffect, useState } from 'react';
 import useConfig from '@/contexts/config';
 import { NETWORK_METADATA, type NetworkKey } from '@/constants/networks.tsx';
@@ -113,7 +112,6 @@ export default function Networks() {
   if (!summaryData.networks || Object.keys(summaryData.networks).length === 0) {
     return (
       <div className="space-y-6 max-w-5xl mx-auto">
-        <XatuCallToAction />
         <div className="text-center py-10 bg-surface/50 backdrop-blur-sm rounded-lg border border-subtle p-8 shadow-sm">
           <Sparkles className="h-12 w-12 mx-auto text-tertiary/50 mb-4" />
           <h3 className="text-xl font-sans font-bold text-primary mb-2">
@@ -130,7 +128,6 @@ export default function Networks() {
 
   return (
     <div className="space-y-6 max-w-5xl mx-auto">
-      <XatuCallToAction />
 
       {/* Page Header */}
       <div className="bg-surface/50 backdrop-blur-sm rounded-lg border border-subtle p-4 shadow-sm">


### PR DESCRIPTION
- Remove repeated XatuCallToAction component from every xatu and xatu-data page to reduce duplication and visual noise
- Extend GoogleFormSystemAlert to also appear on /xatu and /xatu-data routes so the contribution prompt is still reachable