### PR TITLE
feat: replace holesky with hoodi across the frontend

### DIFF
--- a/frontend/src/components/beacon/SlotView.tsx
+++ b/frontend/src/components/beacon/SlotView.tsx
@@ -489,7 +489,7 @@ export function SlotView({
                   </div>
                   <div className="text-[10px] font-mono text-tertiary">
                     by{' '}
-                    {slotData?.entity && ['mainnet', 'holesky', 'sepolia'].includes(network) ? (
+                    {slotData?.entity && ['mainnet', 'hoodi', 'sepolia'].includes(network) ? (
                       <a
                         href={`https://ethseer.io/entity/${slotData.entity}?network=${network}`}
                         target="_blank"
@@ -971,7 +971,7 @@ export function SlotView({
                   <div className="text-sm font-mono">
                     <span className="text-tertiary">
                       by{' '}
-                      {slotData?.entity && ['mainnet', 'holesky', 'sepolia'].includes(network) ? (
+                      {slotData?.entity && ['mainnet', 'hoodi', 'sepolia'].includes(network) ? (
                         <a
                           href={`https://ethseer.io/entity/${slotData.entity}?network=${network}`}
                           target="_blank"

--- a/frontend/src/components/common/NetworkSelector.tsx
+++ b/frontend/src/components/common/NetworkSelector.tsx
@@ -28,7 +28,7 @@ const getNetworkMetadata = (network: string) => {
 };
 
 // Network order priority (lower index = higher priority)
-const NETWORK_ORDER = ['mainnet', 'sepolia', 'holesky', 'hoodi'];
+const NETWORK_ORDER = ['mainnet', 'sepolia', 'hoodi'];
 
 // Sort networks based on predefined order
 const sortNetworks = (networks: string[]): string[] => {

--- a/frontend/src/constants/networks.tsx
+++ b/frontend/src/constants/networks.tsx
@@ -11,14 +11,9 @@ export const NETWORK_METADATA = {
     icon: '🐬',
     color: '#CFB5F0',
   },
-  holesky: {
-    name: 'Holesky',
-    icon: '🐱',
-    color: '#A4E887',
-  },
   hoodi: {
     name: 'Hoodi',
-    icon: '🦊',
+    icon: '🦚',
     color: '#FF9E2C',
   },
 } as const;

--- a/frontend/src/pages/Experiments.tsx
+++ b/frontend/src/pages/Experiments.tsx
@@ -21,7 +21,7 @@ const experiments: ExperimentCard[] = [
     description:
       'Explore node distribution, network health, and community contributions across Ethereum networks.',
     logo: '/xatu.png',
-    href: '/xatu',
+    href: '/xatu-data',
     color: 'from-primary/20 via-accent/20 to-error/20',
   },
   {

--- a/frontend/src/pages/xatu-data/ContributorDetail.tsx
+++ b/frontend/src/pages/xatu-data/ContributorDetail.tsx
@@ -32,7 +32,7 @@ interface ContributorData {
 
 type NetworkNodes = Record<string, ContributorNode[]>;
 
-const NETWORK_ORDER = ['mainnet', 'holesky', 'sepolia'];
+const NETWORK_ORDER = ['mainnet', 'hoodi', 'sepolia'];
 const OFFLINE_THRESHOLD = 3600; // 1 hour in seconds
 
 // Function to generate a deterministic color from a string

--- a/frontend/src/pages/xatu/ContributorDetail.tsx
+++ b/frontend/src/pages/xatu/ContributorDetail.tsx
@@ -30,7 +30,7 @@ interface ContributorData {
 
 type NetworkNodes = Record<string, ContributorNode[]>;
 
-const NETWORK_ORDER = ['mainnet', 'holesky', 'sepolia'];
+const NETWORK_ORDER = ['mainnet', 'hoodi', 'sepolia'];
 const OFFLINE_THRESHOLD = 3600; // 1 hour in seconds
 
 // Function to generate a deterministic color from a string

--- a/frontend/src/pages/xatu/GeographicalChecklist.tsx
+++ b/frontend/src/pages/xatu/GeographicalChecklist.tsx
@@ -35,7 +35,7 @@ interface Summary {
   networks: {
     mainnet: NetworkData;
     sepolia: NetworkData;
-    holesky: NetworkData;
+    hoodi: NetworkData;
   };
 }
 

--- a/frontend/src/pages/xatu/index.tsx
+++ b/frontend/src/pages/xatu/index.tsx
@@ -31,7 +31,7 @@ interface Summary {
   networks: {
     mainnet: NetworkData;
     sepolia: NetworkData;
-    holesky: NetworkData;
+    hoodi: NetworkData;
   };
 }
 

--- a/frontend/src/pages/xatu/networks/index.tsx
+++ b/frontend/src/pages/xatu/networks/index.tsx
@@ -43,7 +43,7 @@ const CLIENT_METADATA: Record<string, { name: string }> = {
 };
 
 // Network order priority (lower index = higher priority)
-const NETWORK_ORDER = ['mainnet', 'sepolia', 'holesky', 'hoodi'];
+const NETWORK_ORDER = ['mainnet', 'hoodi', 'sepolia'];
 
 // Sort networks based on predefined order
 const sortNetworks = (networks: string[]): string[] => {
@@ -128,7 +128,6 @@ export default function Networks() {
 
   return (
     <div className="space-y-6 max-w-5xl mx-auto">
-
       {/* Page Header */}
       <div className="bg-surface/50 backdrop-blur-sm rounded-lg border border-subtle p-4 shadow-sm">
         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3">
@@ -253,56 +252,56 @@ export default function Networks() {
                     <div className="overflow-x-auto rounded border border-subtle/30">
                       <table className="w-full text-xs font-mono border-collapse">
                         <thead className="bg-surface/70">
-                        <tr className="text-2xs text-tertiary">
-                          <th className="text-left font-normal p-2 pr-4 border-b border-subtle/30">
-                            Client
-                          </th>
-                          <th className="text-left font-normal p-2 border-b border-subtle/30 w-full">
-                            Distribution
-                          </th>
-                          <th className="text-right font-normal p-2 pl-4 border-b border-subtle/30">
-                            Share
-                          </th>
-                          <th className="text-right font-normal p-2 pl-4 border-b border-subtle/30">
-                            Total
-                          </th>
-                          <th className="text-right font-normal p-2 pl-4 border-b border-subtle/30">
-                            Community
-                          </th>
-                        </tr>
+                          <tr className="text-2xs text-tertiary">
+                            <th className="text-left font-normal p-2 pr-4 border-b border-subtle/30">
+                              Client
+                            </th>
+                            <th className="text-left font-normal p-2 border-b border-subtle/30 w-full">
+                              Distribution
+                            </th>
+                            <th className="text-right font-normal p-2 pl-4 border-b border-subtle/30">
+                              Share
+                            </th>
+                            <th className="text-right font-normal p-2 pl-4 border-b border-subtle/30">
+                              Total
+                            </th>
+                            <th className="text-right font-normal p-2 pl-4 border-b border-subtle/30">
+                              Community
+                            </th>
+                          </tr>
                         </thead>
                         <tbody>
-                        {displayedClients.map((client, index) => {
-                          const percentage =
-                            totalNodes > 0 ? (client.value / totalNodes) * 100 : 0;
-                          const isLastRow = index === displayedClients.length - 1;
+                          {displayedClients.map((client, index) => {
+                            const percentage =
+                              totalNodes > 0 ? (client.value / totalNodes) * 100 : 0;
+                            const isLastRow = index === displayedClients.length - 1;
 
-                          return (
-                            <tr
-                              key={client.name}
-                              className={`align-middle hover:bg-surface/50 ${!isLastRow ? 'border-b border-subtle/20' : ''}`}
-                            >
-                              <td className="p-2 pr-4 font-medium text-primary">{client.name}</td>
-                              <td className="p-2">
-                                <div className="w-full h-2 bg-surface/70 rounded-full overflow-hidden">
-                                  <div
-                                    className="h-full bg-accent"
-                                    style={{ width: `${percentage}%` }}
-                                  />
-                                </div>
-                              </td>
-                              <td className="text-right p-2 pl-4 text-accent whitespace-nowrap">
-                                {percentage.toFixed(1)}%
-                              </td>
-                              <td className="text-right p-2 pl-4 text-tertiary whitespace-nowrap">
-                                {client.value.toLocaleString()}
-                              </td>
-                              <td className="text-right p-2 pl-4 text-secondary whitespace-nowrap">
-                                {client.publicValue.toLocaleString()}
-                              </td>
-                            </tr>
-                          );
-                        })}
+                            return (
+                              <tr
+                                key={client.name}
+                                className={`align-middle hover:bg-surface/50 ${!isLastRow ? 'border-b border-subtle/20' : ''}`}
+                              >
+                                <td className="p-2 pr-4 font-medium text-primary">{client.name}</td>
+                                <td className="p-2">
+                                  <div className="w-full h-2 bg-surface/70 rounded-full overflow-hidden">
+                                    <div
+                                      className="h-full bg-accent"
+                                      style={{ width: `${percentage}%` }}
+                                    />
+                                  </div>
+                                </td>
+                                <td className="text-right p-2 pl-4 text-accent whitespace-nowrap">
+                                  {percentage.toFixed(1)}%
+                                </td>
+                                <td className="text-right p-2 pl-4 text-tertiary whitespace-nowrap">
+                                  {client.value.toLocaleString()}
+                                </td>
+                                <td className="text-right p-2 pl-4 text-secondary whitespace-nowrap">
+                                  {client.publicValue.toLocaleString()}
+                                </td>
+                              </tr>
+                            );
+                          })}
                         </tbody>
                       </table>
                     </div>

--- a/frontend/src/utils/transformers/networkTransformer.ts
+++ b/frontend/src/utils/transformers/networkTransformer.ts
@@ -61,7 +61,7 @@ export function getActiveNetworks(networks: Network[]): Network[] {
  * Sort networks by a standard order
  */
 export function sortNetworksByPriority(networks: Network[]): Network[] {
-  const priority = ['mainnet', 'holesky', 'sepolia'];
+  const priority = ['mainnet', 'hoodi', 'sepolia'];
 
   return networks.sort((a, b) => {
     const aIndex = priority.indexOf(a.name);


### PR DESCRIPTION
- remove holesky from network metadata, selector order and links
- add hoodi icon (🦚) and color (#FF9E2C) to constants
- update all network lists to use mainnet, hoodi, sepolia order
- change experiments link from /xatu to /xatu-data
- update entity links in SlotView to use hoodi instead of holesky