### PR TITLE
fix(beacon_slots): reduce leader refresh interval from 500s to 1s

### DIFF
--- a/backend/pkg/server/internal/service/beacon_slots/beacon_slots.go
+++ b/backend/pkg/server/internal/service/beacon_slots/beacon_slots.go
@@ -126,7 +126,7 @@ func (b *BeaconSlots) Start(ctx context.Context) error {
 	leaderClient := leader.New(b.log, b.lockerClient, leader.Config{
 		Resource:        ServiceName + "/processing",
 		TTL:             5 * time.Second,
-		RefreshInterval: 500 * time.Second,
+		RefreshInterval: 1 * time.Second, // Refresh every second (5x before TTL expires)
 
 		OnElected: func() {
 			b.log.Info("Became leader for BeaconSlots service")

--- a/backend/pkg/server/internal/service/beacon_slots/locally_built_blocks.go
+++ b/backend/pkg/server/internal/service/beacon_slots/locally_built_blocks.go
@@ -74,7 +74,7 @@ func (p *LocallyBuiltBlocksProcessor) Start(ctx context.Context) error {
 	leaderClient := leader.New(p.log, p.lockerClient, leader.Config{
 		Resource:        ServiceName + "/locally_built_blocks",
 		TTL:             5 * time.Second,
-		RefreshInterval: 500 * time.Second,
+		RefreshInterval: 1 * time.Second, // Refresh every second (5x before TTL expires)
 
 		OnElected: func() {
 			p.log.Info("Became leader for locally built blocks processor")


### PR DESCRIPTION
This prevents premature leader expiration and ensures the service maintains leadership correctly within the 5-second TTL window.