### PR TITLE
feat(prepared-blocks): add multi-slot filtering and REST API support

### DIFF
--- a/backend/pkg/server/internal/service/experiments/table_mappings.go
+++ b/backend/pkg/server/internal/service/experiments/table_mappings.go
@@ -31,7 +31,7 @@ var ExperimentTableMapping = map[string][]string{
 		"fct_block",
 	},
 	"locally-built-blocks": {
-		"fct_block",
+		"fct_prepared_block",
 	},
 }
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -31,4 +31,6 @@ export {
   FilterMetadata,
   NetworkFilterMetadata,
   ErrorResponse,
+  ListPreparedBlocksResponse,
+  PreparedBlock,
 } from './gen/backend/pkg/api/v1/proto/public_pb';

--- a/frontend/src/api/rest/client.ts
+++ b/frontend/src/api/rest/client.ts
@@ -13,6 +13,7 @@ import {
   ListBeaconSlotMevBuilderResponse,
   ListBeaconSlotMevBuilderCountResponse,
   GetExperimentConfigResponse,
+  ListPreparedBlocksResponse,
 } from '../gen/backend/pkg/api/v1/proto/public_pb';
 import { API_V1_ENDPOINTS, buildQueryString, NodeFilters } from './endpoints';
 
@@ -442,6 +443,24 @@ export class RestApiClient {
     }`;
     const response = await this.fetchWithRetry<any>(url);
     return ListBeaconSlotMevBuilderCountResponse.fromJson(response);
+  }
+
+  /**
+   * Get prepared blocks (formerly locally built blocks) with optional slot filtering
+   * @param network Network name
+   * @param params Query parameters including slot filter
+   * @returns Response with prepared blocks data
+   */
+  async getPreparedBlocks(
+    network: string,
+    params?: { slot?: number[]; page_size?: number; page_token?: string },
+  ): Promise<ListPreparedBlocksResponse> {
+    const queryString = params ? buildQueryString(params) : new URLSearchParams();
+    const url = `${this.baseUrl}${API_V1_ENDPOINTS.preparedBlocks(network)}${
+      queryString.toString() ? `?${queryString.toString()}` : ''
+    }`;
+    const response = await this.fetchWithRetry<any>(url);
+    return ListPreparedBlocksResponse.fromJson(response);
   }
 }
 

--- a/frontend/src/api/rest/endpoints.ts
+++ b/frontend/src/api/rest/endpoints.ts
@@ -11,18 +11,28 @@ export const API_V1_ENDPOINTS = {
   experimentConfig: (experimentId: string) => `/api/v1/experiments/${experimentId}/config`,
   // Beacon slot endpoints
   beaconBlock: (network: string, slot: number) => `/api/v1/${network}/beacon/slot/${slot}/block`,
-  beaconBlockTiming: (network: string, slot: number) => `/api/v1/${network}/beacon/slot/${slot}/block/timing`,
-  beaconBlobTiming: (network: string, slot: number) => `/api/v1/${network}/beacon/slot/${slot}/blob/timing`,
-  beaconBlobTotal: (network: string, slot: number) => `/api/v1/${network}/beacon/slot/${slot}/blob/total`,
+  beaconBlockTiming: (network: string, slot: number) =>
+    `/api/v1/${network}/beacon/slot/${slot}/block/timing`,
+  beaconBlobTiming: (network: string, slot: number) =>
+    `/api/v1/${network}/beacon/slot/${slot}/blob/timing`,
+  beaconBlobTotal: (network: string, slot: number) =>
+    `/api/v1/${network}/beacon/slot/${slot}/blob/total`,
   beaconAttestationTiming: (network: string, slot: number) =>
     `/api/v1/${network}/beacon/slot/${slot}/attestation/timing`,
   beaconAttestationCorrectness: (network: string, slot: number) =>
     `/api/v1/${network}/beacon/slot/${slot}/attestation/correctness`,
-  beaconProposerEntity: (network: string, slot: number) => `/api/v1/${network}/beacon/slot/${slot}/proposer/entity`,
-  mevBlock: (network: string, slot: number) => `/api/v1/${network}/beacon/slot/${slot}/mev/deployed`,
-  mevRelayCount: (network: string, slot: number) => `/api/v1/${network}/beacon/slot/${slot}/mev/relay/count`,
-  mevBuilderBid: (network: string, slot: number) => `/api/v1/${network}/beacon/slot/${slot}/mev/builder/bid`,
-  mevBuilderCount: (network: string, slot: number) => `/api/v1/${network}/beacon/slot/${slot}/mev/builder/count`,
+  beaconProposerEntity: (network: string, slot: number) =>
+    `/api/v1/${network}/beacon/slot/${slot}/proposer/entity`,
+  mevBlock: (network: string, slot: number) =>
+    `/api/v1/${network}/beacon/slot/${slot}/mev/deployed`,
+  mevRelayCount: (network: string, slot: number) =>
+    `/api/v1/${network}/beacon/slot/${slot}/mev/relay/count`,
+  mevBuilderBid: (network: string, slot: number) =>
+    `/api/v1/${network}/beacon/slot/${slot}/mev/builder/bid`,
+  mevBuilderCount: (network: string, slot: number) =>
+    `/api/v1/${network}/beacon/slot/${slot}/mev/builder/count`,
+  // Prepared blocks endpoint (formerly locally built blocks)
+  preparedBlocks: (network: string) => `/api/v1/${network}/prepared/blocks`,
 };
 
 /**

--- a/frontend/src/hooks/usePreparedBlocks.ts
+++ b/frontend/src/hooks/usePreparedBlocks.ts
@@ -1,0 +1,191 @@
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import { getRestApiClient } from '@/api';
+import { GetRecentLocallyBuiltBlocksRequest } from '@/api/gen/backend/pkg/api/proto/lab_api_pb';
+import {
+  LocallyBuiltSlotBlocks,
+  LocallyBuiltBlock,
+} from '@/api/gen/backend/pkg/server/proto/beacon_slots/beacon_slots_pb';
+import {
+  ListPreparedBlocksResponse,
+  PreparedBlock,
+} from '@/api/gen/backend/pkg/api/v1/proto/public_pb';
+import { useSlotDataTracker } from '@/contexts/slotDataTracker';
+import useApiMode from '@/contexts/apiMode';
+import useApi from '@/contexts/api';
+import { Timestamp } from '@bufbuild/protobuf';
+
+interface UsePreparedBlocksOptions {
+  network: string;
+  slots?: number[]; // Required for REST API
+  enabled?: boolean;
+}
+
+/**
+ * Unified hook for fetching prepared blocks (formerly locally built blocks)
+ * Automatically chooses between REST and gRPC based on the global API mode
+ * Components using this hook don't need to know about the underlying implementation
+ */
+export function usePreparedBlocks({ network, slots, enabled = true }: UsePreparedBlocksOptions) {
+  const { useRestApi } = useApiMode();
+  const { client } = useApi();
+  const { trackRequest, updateRequest } = useSlotDataTracker();
+
+  // REST implementation
+  const restQuery = useQuery<LocallyBuiltSlotBlocks[], Error>({
+    queryKey: ['preparedBlocks', network, slots],
+    placeholderData: keepPreviousData, // Keep showing old data while fetching new data
+    queryFn: async () => {
+      // Track request for debugging
+      const requestId = trackRequest({
+        slot: slots?.[0] || 0, // Use first slot for tracking
+        network,
+        apiMode: 'REST',
+        endpoints: ['prepared/blocks'],
+      });
+
+      try {
+        const client = await getRestApiClient();
+
+        // Fetch all slots in a single request
+        const response = await client.getPreparedBlocks(network, {
+          slot: slots,
+          page_size: 1000,
+        });
+
+        // Transform response to match existing data structure
+        const slotBlocks: LocallyBuiltSlotBlocks[] = [];
+
+        // Group blocks by slot
+        const blocksBySlot = new Map<number, PreparedBlock[]>();
+        if (response.preparedBlocks && Array.isArray(response.preparedBlocks)) {
+          response.preparedBlocks.forEach((block: PreparedBlock) => {
+            const slot = Number(block.slot);
+            if (!blocksBySlot.has(slot)) {
+              blocksBySlot.set(slot, []);
+            }
+            blocksBySlot.get(slot)!.push(block);
+          });
+        }
+
+        // Convert to LocallyBuiltSlotBlocks structure
+        blocksBySlot.forEach((blocks, slot) => {
+          slotBlocks.push(
+            new LocallyBuiltSlotBlocks({
+              slot: BigInt(slot),
+              blocks: blocks.map(block => transformRestToGrpc(block)),
+            }),
+          );
+        });
+
+        updateRequest(requestId, { payload: response.toJson() });
+        return slotBlocks;
+      } catch (error) {
+        updateRequest(requestId, {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        });
+        throw error;
+      }
+    },
+    enabled: enabled && useRestApi && !!slots?.length, // Only run when REST API mode is enabled and slots provided
+    staleTime: 5000,
+    refetchInterval: 5000,
+    retry: (failureCount, error) => {
+      // Don't retry if no data found (404)
+      if (error?.message?.includes('404')) {
+        return false;
+      }
+      // Retry up to 2 times for other errors
+      return failureCount < 2;
+    },
+  });
+
+  // gRPC-based implementation (fetches recent blocks)
+  const grpcQuery = useQuery<LocallyBuiltSlotBlocks[], Error>({
+    queryKey: ['preparedBlocks-grpc', network],
+    queryFn: async () => {
+      const requestId = trackRequest({
+        slot: 0, // No specific slot for gRPC
+        network,
+        apiMode: 'gRPC',
+      });
+
+      try {
+        const request = new GetRecentLocallyBuiltBlocksRequest({
+          network: network,
+        });
+
+        const response = await client.getRecentLocallyBuiltBlocks(request);
+
+        updateRequest(requestId, {
+          payload: response.slotBlocks,
+        });
+
+        return response.slotBlocks;
+      } catch (error) {
+        updateRequest(requestId, {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        });
+        throw error;
+      }
+    },
+    enabled: enabled && !useRestApi,
+    staleTime: 5000,
+    refetchInterval: 5000,
+  });
+
+  // Return the appropriate query based on the mode
+  if (useRestApi) {
+    return {
+      data: restQuery.data,
+      isLoading: restQuery.isLoading && !restQuery.isPlaceholderData,
+      isError: restQuery.isError,
+      error: restQuery.error,
+      refetch: restQuery.refetch,
+      isRefetching: restQuery.isRefetching || (restQuery.isFetching && restQuery.isPlaceholderData),
+    };
+  } else {
+    return {
+      data: grpcQuery.data,
+      isLoading: grpcQuery.isLoading,
+      isError: grpcQuery.isError,
+      error: grpcQuery.error,
+      refetch: grpcQuery.refetch,
+      isRefetching: grpcQuery.isRefetching,
+    };
+  }
+}
+
+// Helper to transform REST response to match existing gRPC structure
+function transformRestToGrpc(preparedBlock: PreparedBlock): LocallyBuiltBlock {
+  // Convert ISO 8601 string to protobuf Timestamp
+  let slotStartDateTime: Timestamp | undefined;
+  if (preparedBlock.slotStartTime) {
+    const date = new Date(preparedBlock.slotStartTime);
+    slotStartDateTime = Timestamp.fromDate(date);
+  }
+
+  return new LocallyBuiltBlock({
+    slot: BigInt(preparedBlock.slot || 0),
+    slotStartDateTime,
+    metadata: {
+      metaClientName: preparedBlock.client?.name,
+      metaClientVersion: preparedBlock.client?.version,
+      metaClientImplementation: preparedBlock.client?.implementation,
+      metaConsensusImplementation: preparedBlock.consensus?.implementation,
+      metaConsensusVersion: preparedBlock.consensus?.version,
+      metaClientGeoCity: preparedBlock.geo?.city,
+      metaClientGeoCountry: preparedBlock.geo?.country,
+      metaClientGeoCountryCode: preparedBlock.geo?.countryCode,
+    },
+    blockVersion: preparedBlock.blockMetrics?.version,
+    blockTotalBytes: preparedBlock.blockMetrics?.totalBytes,
+    blockTotalBytesCompressed: preparedBlock.blockMetrics?.totalBytesCompressed,
+    executionPayloadValue: preparedBlock.executionMetrics?.valueWei?.toString(),
+    consensusPayloadValue: preparedBlock.executionMetrics?.consensusValueWei?.toString(),
+    executionPayloadBlockNumber: BigInt(preparedBlock.executionMetrics?.blockNumber || 0),
+    executionPayloadGasLimit: BigInt(preparedBlock.executionMetrics?.gasLimit?.toString() || 0),
+    executionPayloadGasUsed: BigInt(preparedBlock.executionMetrics?.gasUsed?.toString() || 0),
+    executionPayloadTransactionsCount: preparedBlock.executionMetrics?.transactionsCount,
+    executionPayloadTransactionsTotalBytes: preparedBlock.executionMetrics?.transactionsTotalBytes,
+  });
+}

--- a/frontend/src/pages/beacon/LocallyBuiltBlocks.tsx
+++ b/frontend/src/pages/beacon/LocallyBuiltBlocks.tsx
@@ -1,34 +1,73 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useNetwork, useConfig } from '@/stores/appStore';
-import useApi from '@/contexts/api';
-import { GetRecentLocallyBuiltBlocksRequest } from '@/api/gen/backend/pkg/api/proto/lab_api_pb';
+import { usePreparedBlocks } from '@/hooks/usePreparedBlocks';
+import { useExperimentConfig } from '@/hooks/useExperimentConfig';
 import {
   LocallyBuiltSlotBlocks,
   LocallyBuiltBlock,
 } from '@/api/gen/backend/pkg/server/proto/beacon_slots/beacon_slots_pb';
-import { LocallyBuiltBlocksDetail, UnifiedBlocksTimeline } from '@/components/beacon/LocallyBuiltBlocks';
+import {
+  LocallyBuiltBlocksDetail,
+  UnifiedBlocksTimeline,
+} from '@/components/beacon/LocallyBuiltBlocks';
 import { ChevronLeft, Clock, AlertCircle } from 'lucide-react';
 import useBeacon from '@/contexts/beacon';
+import { extractSlotBounds } from '@/types/slot';
 
-// Refresh interval in milliseconds
-const REFRESH_INTERVAL = 5000;
-// Maximum number of slots to keep in memory
-const MAX_SLOTS = 64;
+const SLOTS_TO_FETCH = 10; // Number of slots to fetch for REST API
 
 export function LocallyBuiltBlocks() {
   const { selectedNetwork } = useNetwork();
   const { config } = useConfig();
-  const [data, setData] = useState<LocallyBuiltSlotBlocks[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [selectedBlock, setSelectedBlock] = useState<LocallyBuiltBlock | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date>(new Date());
   const [currentSlot, setCurrentSlot] = useState<number | null>(null);
   const { getBeaconClock } = useBeacon();
-  const { client } = useApi();
+
+  // Fetch experiment config to get data availability bounds
+  const { data: experimentConfig } = useExperimentConfig('locally-built-blocks', {
+    refetchInterval: 10_000,
+    staleTime: 10_000,
+  });
+
+  // Extract slot bounds from experiment config
+  const slotBounds = useMemo(() => {
+    if (!experimentConfig) return null;
+    return extractSlotBounds(experimentConfig, selectedNetwork);
+  }, [experimentConfig, selectedNetwork]);
+
+  // Calculate slots to fetch based on experiment config and current slot
+  const slotsToFetch = useMemo(() => {
+    if (!slotBounds) return [];
+
+    // Use safeSlot from experiment config if available, otherwise use headSlot
+    const latestAvailableSlot = slotBounds.safeSlot > 0 ? slotBounds.safeSlot : slotBounds.headSlot;
+
+    if (latestAvailableSlot === 0) {
+      // If we don't have data availability info yet, fall back to current slot
+      if (!currentSlot) return [];
+      const slots: number[] = [];
+      for (let i = 0; i < SLOTS_TO_FETCH; i++) {
+        const slot = currentSlot - i;
+        if (slot >= 0) slots.push(slot);
+      }
+      return slots;
+    }
+
+    // Fetch the most recent N slots within the available range
+    const slots: number[] = [];
+    for (let i = 0; i < SLOTS_TO_FETCH; i++) {
+      const slot = latestAvailableSlot - i;
+      if (slot >= slotBounds.minSlot) {
+        slots.push(slot);
+      }
+    }
+    return slots;
+  }, [slotBounds, currentSlot]);
 
   // Check if this experiment is available for the current network
   const isExperimentAvailable = () => {
-    if (!config?.experiments) return true; // Default to available if no config
+    if (!config?.experiments) return true;
     const experiment = config.experiments.find(exp => exp.id === 'locally-built-blocks');
     return experiment?.enabled && experiment?.networks?.includes(selectedNetwork);
   };
@@ -39,6 +78,13 @@ export function LocallyBuiltBlocks() {
     const experiment = config.experiments.find(exp => exp.id === 'locally-built-blocks');
     return experiment?.enabled ? experiment?.networks || [] : [];
   };
+
+  // Use the unified hook - it will automatically choose between REST and gRPC
+  const { data, isLoading, refetch } = usePreparedBlocks({
+    network: selectedNetwork,
+    slots: slotsToFetch, // Always provide slots (REST needs them, gRPC ignores them)
+    enabled: isExperimentAvailable() && !selectedBlock && slotsToFetch.length > 0,
+  });
 
   // Update current slot from wallclock
   useEffect(() => {
@@ -55,113 +101,51 @@ export function LocallyBuiltBlocks() {
     return () => clearInterval(interval);
   }, [selectedNetwork, getBeaconClock]);
 
-  // Function to fetch and merge data
-  const fetchData = useCallback(
-    async (isInitial = false) => {
-      try {
-        if (isInitial) {
-          setIsLoading(true);
-        }
-
-        const request = new GetRecentLocallyBuiltBlocksRequest({
-          network: selectedNetwork,
-        });
-
-        const response = await client.getRecentLocallyBuiltBlocks(request);
-        const newSlotBlocks = response.slotBlocks;
-
-        // If it's an initial load, just set the data
-        if (isInitial || data.length === 0) {
-          setData(newSlotBlocks);
-        } else {
-          // Otherwise, merge the new data with existing data
-          setData(prevData => {
-            // Create a map of existing slots by slot number for quick lookup
-            const existingSlotMap = new Map(prevData.map(slotBlock => [slotBlock.slot, slotBlock]));
-
-            // Process each new slot block
-            newSlotBlocks.forEach(newSlotBlock => {
-              const existingSlot = existingSlotMap.get(newSlotBlock.slot);
-
-              if (existingSlot) {
-                // If the slot already exists, add any new blocks that aren't already there
-                const existingBlockIds = new Set(
-                  existingSlot.blocks.map(block => `${block.slot}-${block.metadata?.metaClientName}`)
-                );
-
-                newSlotBlock.blocks.forEach(newBlock => {
-                  const blockId = `${newBlock.slot}-${newBlock.metadata?.metaClientName}`;
-                  if (!existingBlockIds.has(blockId)) {
-                    existingSlot.blocks.push(newBlock);
-                  }
-                });
-              } else {
-                // If it's a new slot, add it to the map
-                existingSlotMap.set(newSlotBlock.slot, newSlotBlock);
-              }
-            });
-
-            // Convert the map values back to an array and sort by slot (most recent first)
-            const mergedData = Array.from(existingSlotMap.values()).sort((a, b) => Number(b.slot) - Number(a.slot));
-
-            // Limit the size to prevent memory issues
-            return mergedData.slice(0, MAX_SLOTS);
-          });
-        }
-
-        setLastUpdated(new Date());
-      } catch (error) {
-        console.error('Error fetching locally built blocks:', error);
-      } finally {
-        if (isInitial) {
-          setIsLoading(false);
-        }
-      }
-    },
-    [selectedNetwork, data.length, client]
-  ); // Added data.length dependency
-
-  // Initial data fetch when network changes
+  // Update last updated time when data changes
   useEffect(() => {
-    fetchData(true);
-  }, [selectedNetwork, fetchData]); // Only depend on selectedNetwork
-
-  // Set up automatic refresh interval
-  useEffect(() => {
-    const intervalId = setInterval(() => {
-      if (!selectedBlock) {
-        // Only refresh when not viewing a specific block
-        fetchData(false);
-      }
-    }, REFRESH_INTERVAL);
-
-    // Clean up interval on unmount
-    return () => clearInterval(intervalId);
-  }, [fetchData, selectedBlock]);
-
-  const handleBack = () => {
-    setSelectedBlock(null);
-  };
+    if (data) {
+      setLastUpdated(new Date());
+    }
+  }, [data]);
 
   // Format the last updated time
   const formatLastUpdated = () => {
     return lastUpdated.toLocaleTimeString();
   };
 
-  // Show not available message if experiment isn't enabled for this network
+  // Show not available message if experiment isn't enabled
   if (!isExperimentAvailable()) {
     const supportedNetworks = getSupportedNetworks();
     return (
       <div className="flex-1 flex items-center justify-center min-h-[50vh]">
         <div className="text-center max-w-md mx-auto">
           <AlertCircle className="w-12 h-12 text-accent/60 mx-auto mb-4" />
-          <h2 className="text-xl font-sans font-bold text-primary mb-2">Experiment Not Available</h2>
+          <h2 className="text-xl font-sans font-bold text-primary mb-2">
+            Experiment Not Available
+          </h2>
           <p className="text-sm font-mono text-secondary mb-4">
             Locally Built Blocks is not enabled for {selectedNetwork}
           </p>
           {supportedNetworks.length > 0 && (
-            <p className="text-xs font-mono text-tertiary">Available on: {supportedNetworks.join(', ')}</p>
+            <p className="text-xs font-mono text-tertiary">
+              Available on: {supportedNetworks.join(', ')}
+            </p>
           )}
+        </div>
+      </div>
+    );
+  }
+
+  // Show message if no data is available yet
+  if (!slotBounds || !slotBounds.hasData) {
+    return (
+      <div className="flex-1 flex items-center justify-center min-h-[50vh]">
+        <div className="text-center max-w-md mx-auto">
+          <AlertCircle className="w-12 h-12 text-accent/60 mx-auto mb-4" />
+          <h2 className="text-xl font-sans font-bold text-primary mb-2">No Data Available</h2>
+          <p className="text-sm font-mono text-secondary mb-4">
+            No prepared blocks data is available for {selectedNetwork} yet.
+          </p>
         </div>
       </div>
     );
@@ -172,10 +156,9 @@ export function LocallyBuiltBlocks() {
       {selectedBlock ? (
         // Detail View
         <div className="space-y-4">
-          {/* Back Button */}
           <div>
             <button
-              onClick={handleBack}
+              onClick={() => setSelectedBlock(null)}
               className="flex items-center gap-1.5 px-3 py-1.5 bg-surface/40 hover:bg-surface/60 rounded-md text-tertiary hover:text-primary transition-all duration-200"
             >
               <ChevronLeft className="w-4 h-4" />
@@ -187,21 +170,20 @@ export function LocallyBuiltBlocks() {
       ) : (
         // Overview View
         <>
-          {/* Integrated Contextual Header */}
+          {/* Header */}
           <div className="mb-6 p-4 bg-surface/50 rounded-lg border border-subtle">
             <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
-              {/* Left: Title & Description */}
               <div>
-                <h2 className="text-xl font-sans font-bold text-primary mb-1">Locally Built Blocks</h2>
+                <h2 className="text-xl font-sans font-bold text-primary mb-1">
+                  Locally Built Blocks
+                </h2>
                 <p className="text-sm font-mono text-secondary max-w-3xl">
-                  Blocks locally built by sentry nodes (not necessarily canonical/broadcasted). Useful for analyzing
-                  client block building capabilities based on mempool contents.
+                  Blocks locally built by sentry nodes (not necessarily canonical/broadcasted).
+                  Useful for analyzing client block building capabilities based on mempool contents.
                 </p>
               </div>
-              {/* Right: Controls/Actions */}
-              <div className="flex items-center gap-2"></div>
             </div>
-            {/* Optional: Stats/Info Row */}
+
             <div className="mt-4 pt-3 border-t border-subtle/50 flex flex-wrap gap-x-4 gap-y-2 text-xs font-mono text-tertiary">
               <div className="flex items-center gap-1.5">
                 <Clock className="w-3 h-3 text-accent/70" />
@@ -212,7 +194,7 @@ export function LocallyBuiltBlocks() {
 
           {/* Unified Blocks Timeline */}
           <UnifiedBlocksTimeline
-            data={data}
+            data={data || []}
             isLoading={isLoading}
             onSelectBlock={setSelectedBlock}
             currentSlot={currentSlot}

--- a/frontend/src/types/slot.ts
+++ b/frontend/src/types/slot.ts
@@ -24,6 +24,7 @@ export function extractSlotBounds(
     maxSlot: Number(dataAvailability.maxSlot ?? 0),
     safeSlot: Number(dataAvailability.safeSlot ?? 0),
     headSlot: Number(dataAvailability.headSlot ?? 0),
+    hasData: Boolean(dataAvailability.hasData ?? false),
   };
 }
 
@@ -66,6 +67,7 @@ export interface SlotBounds {
   maxSlot: number;
   safeSlot: number;
   headSlot: number;
+  hasData?: boolean;
 }
 
 export interface SlotProviderProps {


### PR DESCRIPTION
- Allow querying prepared blocks with multiple slot values
- Switch experiment table mapping from fct_block to fct_prepared_block
- Expose ListPreparedBlocksResponse and PreparedBlock types to frontend
- Add REST client method for fetching prepared blocks with slot filter
- Create unified usePreparedBlocks hook that auto-selects REST or gRPC
- Update LocallyBuiltBlocks page to use new hook and experiment config