### PR TITLE
fix(BuilderNamesStore): handle missing builder-names files gracefully

### DIFF
--- a/frontend/src/stores/BuilderNamesStore.ts
+++ b/frontend/src/stores/BuilderNamesStore.ts
@@ -27,7 +27,21 @@ class BuilderNamesStore {
           const response = await fetch(`/data/${network}-builders.json`);
 
           if (!response.ok) {
+            // If file doesn't exist, just skip loading without error
+            if (response.status === 404) {
+              console.log(`Builder names file not found for network: ${network}`);
+              resolve();
+              return;
+            }
             throw new Error(`Failed to fetch builder names: ${response.status}`);
+          }
+
+          // Check if response is JSON before parsing
+          const contentType = response.headers.get('content-type');
+          if (!contentType || !contentType.includes('application/json')) {
+            console.warn(`Builder names file is not JSON for network: ${network}`);
+            resolve();
+            return;
           }
 
           const data = await response.json();


### PR DESCRIPTION
We only have `mainnet-builders.json`.

```
Error loading builder names: SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data BuilderNamesStore.ts:57:19
      fetchData BuilderNamesStore.ts:57
      loadPromise BuilderNamesStore.ts:63
      loadBuilderNames BuilderNamesStore.ts:23
      BuildersRelaysPanel BuildersRelaysPanel.tsx:42
```

- return early on 404 instead of throwing, avoiding crashes when a network lacks the file
- skip non-JSON responses to prevent runtime parse errors