### PR TITLE
feat: add ClientSelect component for Ethereum client selection

### DIFF
--- a/src/components/Ethereum/ClientSelect/ClientSelect.stories.tsx
+++ b/src/components/Ethereum/ClientSelect/ClientSelect.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { ClientSelect } from './ClientSelect';
+
+const mockClients = [
+  { name: 'lighthouse', count: 125 },
+  { name: 'prysm', count: 85 },
+  { name: 'nimbus', count: 35 },
+  { name: 'teku', count: 20 },
+  { name: 'lodestar', count: 10 },
+];
+
+const meta: Meta<typeof ClientSelect> = {
+  title: 'Components/Ethereum/ClientSelect',
+  component: ClientSelect,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <div className="min-w-80 rounded-lg bg-surface p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default client selector with label
+ */
+export const Default: Story = {
+  render: () => {
+    const [value, setValue] = useState('all');
+    return <ClientSelect value={value} onChange={setValue} clients={mockClients} showLabel />;
+  },
+};
+
+/**
+ * Client selector without label
+ */
+export const WithoutLabel: Story = {
+  render: () => {
+    const [value, setValue] = useState('all');
+    return <ClientSelect value={value} onChange={setValue} clients={mockClients} showLabel={false} />;
+  },
+};
+
+/**
+ * Client selector with custom label
+ */
+export const CustomLabel: Story = {
+  render: () => {
+    const [value, setValue] = useState('all');
+    return <ClientSelect value={value} onChange={setValue} clients={mockClients} showLabel label="Select Client" />;
+  },
+};
+
+/**
+ * Client selector with pre-selected value
+ */
+export const PreSelected: Story = {
+  render: () => {
+    const [value, setValue] = useState('lighthouse');
+    return <ClientSelect value={value} onChange={setValue} clients={mockClients} showLabel />;
+  },
+};

--- a/src/components/Ethereum/ClientSelect/ClientSelect.tsx
+++ b/src/components/Ethereum/ClientSelect/ClientSelect.tsx
@@ -1,0 +1,86 @@
+import { type JSX, useMemo } from 'react';
+import { SelectMenu, type SelectMenuOption } from '@/components/Forms/SelectMenu';
+import { ClientLogo } from '@/components/Ethereum/ClientLogo';
+import type { ClientSelectProps } from './ClientSelect.types';
+
+/**
+ * Client implementation selector dropdown component.
+ *
+ * Displays a list of available Ethereum client implementations and allows selecting one.
+ * Shows client logos alongside client names and node counts.
+ *
+ * Features:
+ * - Includes "All Clients" option by default
+ * - Shows client logo using ClientLogo component
+ * - Displays node count for each client
+ * - Keyboard accessible
+ * - Dark mode support
+ *
+ * @example
+ * ```tsx
+ * const [selectedClient, setSelectedClient] = useState('all');
+ * const clients = [
+ *   { name: 'lighthouse', count: 150 },
+ *   { name: 'prysm', count: 120 },
+ *   { name: 'teku', count: 80 },
+ * ];
+ *
+ * // With label
+ * <ClientSelect
+ *   value={selectedClient}
+ *   onChange={setSelectedClient}
+ *   clients={clients}
+ * />
+ *
+ * // Without label
+ * <ClientSelect
+ *   value={selectedClient}
+ *   onChange={setSelectedClient}
+ *   clients={clients}
+ *   showLabel={false}
+ * />
+ *
+ * // Custom label
+ * <ClientSelect
+ *   value={selectedClient}
+ *   onChange={setSelectedClient}
+ *   clients={clients}
+ *   label="Select Client"
+ * />
+ * ```
+ */
+export function ClientSelect({
+  value,
+  onChange,
+  clients,
+  showLabel = true,
+  label = 'Client Implementation',
+  expandToFit = false,
+}: ClientSelectProps): JSX.Element {
+  const options: SelectMenuOption<string>[] = useMemo(
+    () => [
+      {
+        value: 'all',
+        label: 'All Clients',
+      },
+      ...clients.map(client => ({
+        value: client.name,
+        label: `${client.name} (${client.count})`,
+        icon: <ClientLogo client={client.name} size={20} />,
+      })),
+    ],
+    [clients]
+  );
+
+  return (
+    <SelectMenu
+      value={value}
+      onChange={onChange}
+      options={options}
+      showLabel={showLabel}
+      label={label}
+      placeholder="Select client"
+      expandToFit={expandToFit}
+    />
+  );
+}

--- a/src/components/Ethereum/ClientSelect/ClientSelect.types.ts
+++ b/src/components/Ethereum/ClientSelect/ClientSelect.types.ts
@@ -1,0 +1,37 @@
+export interface ClientOption {
+  /**
+   * Client implementation name (e.g., "lighthouse", "prysm", "teku")
+   */
+  name: string;
+  /**
+   * Number of nodes running this client
+   */
+  count: number;
+}
+
+export interface ClientSelectProps {
+  /**
+   * Currently selected client name or "all"
+   */
+  value: string;
+  /**
+   * Callback when client selection changes
+   */
+  onChange: (value: string) => void;
+  /**
+   * Available client implementations with their counts
+   */
+  clients: ClientOption[];
+  /**
+   * Whether to show the label (default: true)
+   */
+  showLabel?: boolean;
+  /**
+   * Custom label text (default: "Client Implementation")
+   */
+  label?: string;
+  /**
+   * Whether to expand the select menu to fit its content (default: false)
+   */
+  expandToFit?: boolean;
+}

--- a/src/components/Ethereum/ClientSelect/index.ts
+++ b/src/components/Ethereum/ClientSelect/index.ts
@@ -1,0 +1,2 @@
+export { ClientSelect } from './ClientSelect';
+export type { ClientSelectProps, ClientOption } from './ClientSelect.types';


### PR DESCRIPTION
Introduce a reusable dropdown component that lets users pick an Ethereum client implementation. It displays client logos, names and node counts, supports an “All Clients” option, and is fully documented with Storybook stories.

<img width="1032" height="761" alt="Screenshot 2025-10-22 at 06 47 53" src="https://github.com/user-attachments/assets/6198329e-ed90-4c57-885f-f60170494c69" />
