### PR TITLE
refactor(stories): rename story titles to use consistent domain paths

### DIFF
--- a/src/pages/ethereum/live/components/AttestationArrivals/AttestationArrivals.stories.tsx
+++ b/src/pages/ethereum/live/components/AttestationArrivals/AttestationArrivals.stories.tsx
@@ -51,7 +51,7 @@ const convertToChartValues = (data: AttestationDataPoint[], currentTime: number)
 };
 
 const meta = {
-  title: 'Pages/Experiments/SlotView/AttestationArrivals',
+  title: 'Pages/Ethereum/SlotView/AttestationArrivals',
   component: AttestationArrivals,
   parameters: {
     layout: 'padded',

--- a/src/pages/ethereum/live/components/DataColumnDataAvailability/DataColumnDataAvailability.stories.tsx
+++ b/src/pages/ethereum/live/components/DataColumnDataAvailability/DataColumnDataAvailability.stories.tsx
@@ -4,7 +4,7 @@ import { DataColumnDataAvailability } from './DataColumnDataAvailability';
 import type { DataColumnFirstSeenPoint } from './DataColumnDataAvailability.types';
 
 const meta: Meta<typeof DataColumnDataAvailability> = {
-  title: 'Pages/Experiments/SlotView/DataColumnDataAvailability',
+  title: 'Pages/Ethereum/SlotView/DataColumnDataAvailability',
   component: DataColumnDataAvailability,
   parameters: {
     layout: 'centered',

--- a/src/pages/ethereum/live/components/Sidebar/Sidebar.stories.tsx
+++ b/src/pages/ethereum/live/components/Sidebar/Sidebar.stories.tsx
@@ -6,7 +6,7 @@ import type { TimelineItem } from '@/components/Lists/ScrollingTimeline/Scrollin
 import { Badge } from '@/components/Elements/Badge';
 
 const meta = {
-  title: 'Pages/Experiments/SlotView/Sidebar',
+  title: 'Pages/Ethereum/SlotView/Sidebar',
   component: Sidebar,
   parameters: {
     layout: 'padded',

--- a/src/pages/ethereum/live/components/Timeline/Timeline.stories.tsx
+++ b/src/pages/ethereum/live/components/Timeline/Timeline.stories.tsx
@@ -4,7 +4,7 @@ import { Timeline } from './Timeline';
 import { DEFAULT_BEACON_SLOT_PHASES } from '@/utils/beacon';
 
 const meta = {
-  title: 'Pages/Experiments/SlotView/Timeline',
+  title: 'Pages/Ethereum/SlotView/Timeline',
   component: Timeline,
   parameters: {
     layout: 'padded',

--- a/src/pages/xatu/contributors/components/UserCard/UserCard.stories.tsx
+++ b/src/pages/xatu/contributors/components/UserCard/UserCard.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { UserCard } from './UserCard';
 
 const meta = {
-  title: 'Pages/Contributors/UserCard',
+  title: 'Pages/Xatu/Contributors/UserCard',
   component: UserCard,
   parameters: {
     layout: 'padded',

--- a/src/pages/xatu/contributors/components/UserCardSkeleton/UserCardSkeleton.stories.tsx
+++ b/src/pages/xatu/contributors/components/UserCardSkeleton/UserCardSkeleton.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { UserCardSkeleton } from './UserCardSkeleton';
 
 const meta = {
-  title: 'Pages/Contributors/UserCardSkeleton',
+  title: 'Pages/Xatu/Contributors/UserCardSkeleton',
   component: UserCardSkeleton,
   parameters: {
     layout: 'centered',

--- a/src/pages/xatu/contributors/components/UserDetailsSkeleton/UserDetailsSkeleton.stories.tsx
+++ b/src/pages/xatu/contributors/components/UserDetailsSkeleton/UserDetailsSkeleton.stories.tsx
@@ -4,7 +4,7 @@ import { Header } from '@/components/Layout/Header';
 import { UserDetailsSkeleton } from './UserDetailsSkeleton';
 
 const meta = {
-  title: 'Pages/Contributors/UserDetailsSkeleton',
+  title: 'Pages/Xatu/Contributors/UserDetailsSkeleton',
   component: UserDetailsSkeleton,
   parameters: {
     layout: 'fullscreen',

--- a/src/pages/xatu/fork-readiness/components/ClientReadinessCard/ClientReadinessCard.stories.tsx
+++ b/src/pages/xatu/fork-readiness/components/ClientReadinessCard/ClientReadinessCard.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ClientReadinessCard } from './ClientReadinessCard';
 
 const meta = {
-  title: 'Pages/Experiments/ForkReadiness/ClientReadinessCard',
+  title: 'Pages/Xatu/ForkReadiness/ClientReadinessCard',
   component: ClientReadinessCard,
   parameters: {
     layout: 'padded',

--- a/src/pages/xatu/fork-readiness/components/ForkReadinessLoading/ForkReadinessLoading.stories.tsx
+++ b/src/pages/xatu/fork-readiness/components/ForkReadinessLoading/ForkReadinessLoading.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ForkReadinessLoading } from './ForkReadinessLoading';
 
 const meta: Meta<typeof ForkReadinessLoading> = {
-  title: 'Pages/Experiments/ForkReadiness/ForkReadinessLoading',
+  title: 'Pages/Xatu/ForkReadiness/ForkReadinessLoading',
   component: ForkReadinessLoading,
   decorators: [
     Story => (

--- a/src/pages/xatu/geographical-checklist/components/GeographicalChecklistSkeleton/GeographicalChecklistSkeleton.stories.tsx
+++ b/src/pages/xatu/geographical-checklist/components/GeographicalChecklistSkeleton/GeographicalChecklistSkeleton.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { GeographicalChecklistSkeleton } from './GeographicalChecklistSkeleton';
 
 const meta = {
-  title: 'Pages/Experiments/Geographical Checklist/GeographicalChecklistSkeleton',
+  title: 'Pages/Xatu/Geographical Checklist/GeographicalChecklistSkeleton',
   component: GeographicalChecklistSkeleton,
   decorators: [
     Story => (

--- a/src/pages/xatu/geographical-checklist/components/GeographicalFilters/GeographicalFilters.stories.tsx
+++ b/src/pages/xatu/geographical-checklist/components/GeographicalFilters/GeographicalFilters.stories.tsx
@@ -21,7 +21,7 @@ const mockCountries = [
 ];
 
 const meta = {
-  title: 'Pages/Experiments/Geographical Checklist/GeographicalFilters',
+  title: 'Pages/Xatu/Geographical Checklist/GeographicalFilters',
   component: GeographicalFilters,
   decorators: [
     Story => {

--- a/src/pages/xatu/geographical-checklist/components/GeographicalListView/GeographicalListView.stories.tsx
+++ b/src/pages/xatu/geographical-checklist/components/GeographicalListView/GeographicalListView.stories.tsx
@@ -62,7 +62,7 @@ const mockContinents = new Map<ContinentCode, ContinentData>([
 ]);
 
 const meta = {
-  title: 'Pages/Experiments/Geographical Checklist/GeographicalListView',
+  title: 'Pages/Xatu/Geographical Checklist/GeographicalListView',
   component: GeographicalListView,
   decorators: [
     Story => (

--- a/src/pages/xatu/geographical-checklist/components/GeographicalMapView/GeographicalMapView.stories.tsx
+++ b/src/pages/xatu/geographical-checklist/components/GeographicalMapView/GeographicalMapView.stories.tsx
@@ -119,7 +119,7 @@ const mockNodes: ProcessedNode[] = [
 ] as ProcessedNode[];
 
 const meta = {
-  title: 'Pages/Experiments/Geographical Checklist/GeographicalMapView',
+  title: 'Pages/Xatu/Geographical Checklist/GeographicalMapView',
   component: GeographicalMapView,
   decorators: [
     Story => (

--- a/src/pages/xatu/locally-built-blocks/components/LocallyBuiltBlocksSkeleton/LocallyBuiltBlocksSkeleton.stories.tsx
+++ b/src/pages/xatu/locally-built-blocks/components/LocallyBuiltBlocksSkeleton/LocallyBuiltBlocksSkeleton.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { LocallyBuiltBlocksSkeleton } from './LocallyBuiltBlocksSkeleton';
 
 const meta = {
-  title: 'Pages/Experiments/Locally Built Blocks/LocallyBuiltBlocksSkeleton',
+  title: 'Pages/Xatu/Locally Built Blocks/LocallyBuiltBlocksSkeleton',
   component: LocallyBuiltBlocksSkeleton,
   decorators: [
     Story => (


### PR DESCRIPTION
Before:

<img width="322" height="562" alt="Screenshot 2025-10-24 at 16 21 07" src="https://github.com/user-attachments/assets/28cfdbca-47a1-4347-bd13-a9b3c62ff8f1" />



After:

<img width="298" height="293" alt="Screenshot 2025-10-24 at 16 26 00" src="https://github.com/user-attachments/assets/e93f4b55-c51e-41b4-b7ee-bd9bb587fcf5" />
