### PR TITLE
feat: add missed attestations by entity chart to slot details

### DIFF
--- a/src/components/Ethereum/AttestationsByEntity/AttestationsByEntity.stories.tsx
+++ b/src/components/Ethereum/AttestationsByEntity/AttestationsByEntity.stories.tsx
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { AttestationsByEntity } from './AttestationsByEntity';
+
+const meta = {
+  title: 'Components/Ethereum/AttestationsByEntity',
+  component: AttestationsByEntity,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <div className="min-w-[600px] rounded-sm bg-surface p-6">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof AttestationsByEntity>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Shows the top 10 entities with missed attestations
+ */
+export const MissedAttestations: Story = {
+  args: {
+    data: [
+      { entity: 'Lido', count: 234 },
+      { entity: 'Coinbase', count: 156 },
+      { entity: 'Kraken', count: 89 },
+      { entity: 'Binance', count: 67 },
+      { entity: 'Rocket Pool', count: 45 },
+      { entity: 'Staked.us', count: 34 },
+      { entity: 'Bitcoin Suisse', count: 28 },
+      { entity: 'Figment', count: 23 },
+      { entity: 'Stakewise', count: 18 },
+      { entity: 'Allnodes', count: 12 },
+    ],
+    title: 'Missed Attestations by Entity',
+    subtitle: '706 total missed attestations',
+    anchorId: 'missed-attestations',
+  },
+};
+
+/**
+ * Shows the top attesters (successful attestations)
+ */
+export const TopAttesters: Story = {
+  args: {
+    data: [
+      { entity: 'Lido', count: 12543 },
+      { entity: 'Coinbase', count: 8932 },
+      { entity: 'Kraken', count: 6721 },
+      { entity: 'Binance', count: 5834 },
+      { entity: 'Rocket Pool', count: 4521 },
+      { entity: 'Staked.us', count: 3210 },
+      { entity: 'Bitcoin Suisse', count: 2567 },
+      { entity: 'Figment', count: 1987 },
+      { entity: 'Stakewise', count: 1543 },
+      { entity: 'Allnodes', count: 1234 },
+    ],
+    title: 'Top Attesters by Entity',
+    subtitle: '49,092 total attestations',
+    anchorId: 'top-attesters',
+  },
+};
+
+/**
+ * Shows a vertical bar chart orientation
+ */
+export const VerticalOrientation: Story = {
+  args: {
+    data: [
+      { entity: 'Lido', count: 234 },
+      { entity: 'Coinbase', count: 156 },
+      { entity: 'Kraken', count: 89 },
+      { entity: 'Binance', count: 67 },
+      { entity: 'Rocket Pool', count: 45 },
+    ],
+    title: 'Missed Attestations (Vertical)',
+    subtitle: '591 total missed',
+    anchorId: 'missed-vertical',
+    orientation: 'vertical',
+  },
+};
+
+/**
+ * Shows fewer entities (top 5 instead of 10)
+ */
+export const Top5Only: Story = {
+  args: {
+    data: [
+      { entity: 'Lido', count: 234 },
+      { entity: 'Coinbase', count: 156 },
+      { entity: 'Kraken', count: 89 },
+      { entity: 'Binance', count: 67 },
+      { entity: 'Rocket Pool', count: 45 },
+    ],
+    title: 'Top 5 Entities - Missed Attestations',
+    subtitle: '591 total missed attestations',
+    anchorId: 'top-5',
+  },
+};
+
+/**
+ * Shows empty state when no data is available
+ */
+export const EmptyState: Story = {
+  args: {
+    data: [],
+    title: 'Missed Attestations by Entity',
+    anchorId: 'empty-state',
+    emptyMessage: 'No missed attestations for this slot',
+  },
+};
+
+/**
+ * Shows custom empty message
+ */
+export const CustomEmptyMessage: Story = {
+  args: {
+    data: [],
+    title: 'Attestations by Entity',
+    anchorId: 'custom-empty',
+    emptyMessage: 'Perfect! All validators attested successfully.',
+  },
+};

--- a/src/components/Ethereum/AttestationsByEntity/AttestationsByEntity.tsx
+++ b/src/components/Ethereum/AttestationsByEntity/AttestationsByEntity.tsx
@@ -1,0 +1,97 @@
+import type { JSX } from 'react';
+import { useMemo } from 'react';
+import { PopoutCard } from '@/components/Layout/PopoutCard';
+import { BarChart } from '@/components/Charts/Bar';
+import type { AttestationsByEntityProps } from './AttestationsByEntity.types';
+
+/**
+ * AttestationsByEntity - Generic component for displaying entity-based attestation metrics
+ *
+ * Displays a bar chart showing counts by entity (e.g., staking providers). Can be used for
+ * missed attestations, successful attestations, or any other entity-based metric.
+ *
+ * @example
+ * ```tsx
+ * // Missed attestations
+ * <AttestationsByEntity
+ *   data={[
+ *     { entity: 'Lido', count: 45 },
+ *     { entity: 'Coinbase', count: 23 },
+ *   ]}
+ *   title="Missed Attestations by Entity"
+ *   subtitle="68 total missed"
+ *   anchorId="missed-attestations"
+ * />
+ *
+ * // Successful attestations
+ * <AttestationsByEntity
+ *   data={[
+ *     { entity: 'Lido', count: 2500 },
+ *     { entity: 'Coinbase', count: 1800 },
+ *   ]}
+ *   title="Top Attesters"
+ *   subtitle="15,234 total attestations"
+ *   anchorId="top-attesters"
+ * />
+ * ```
+ */
+export function AttestationsByEntity({
+  data,
+  title = 'Attestations by Entity',
+  subtitle,
+  anchorId = 'attestations-by-entity',
+  orientation = 'horizontal',
+  barWidth = '60%',
+  emptyMessage = 'No data available',
+}: AttestationsByEntityProps): JSX.Element {
+  // Prepare data for the bar chart
+  const { values, labels } = useMemo(() => {
+    if (data.length === 0) {
+      return { values: [], labels: [] };
+    }
+
+    return {
+      values: data.map(item => item.count),
+      labels: data.map(item => item.entity),
+    };
+  }, [data]);
+
+  // Handle empty data
+  if (data.length === 0) {
+    return (
+      <PopoutCard title={title} anchorId={anchorId} modalSize="xl">
+        {({ inModal }) => (
+          <div
+            className={
+              inModal
+                ? 'flex h-96 items-center justify-center text-muted'
+                : 'flex h-64 items-center justify-center text-muted'
+            }
+          >
+            <p>{emptyMessage}</p>
+          </div>
+        )}
+      </PopoutCard>
+    );
+  }
+
+  return (
+    <PopoutCard title={title} anchorId={anchorId} subtitle={subtitle} modalSize="xl">
+      {({ inModal }) => (
+        <div className={inModal ? 'h-96' : 'h-64'}>
+          <BarChart
+            data={values}
+            labels={labels}
+            height="100%"
+            orientation={orientation}
+            barWidth={barWidth}
+            showLabel={true}
+            labelPosition={orientation === 'horizontal' ? 'right' : 'top'}
+            animationDuration={150}
+            categoryLabelInterval={0}
+          />
+        </div>
+      )}
+    </PopoutCard>
+  );
+}

--- a/src/components/Ethereum/AttestationsByEntity/AttestationsByEntity.types.ts
+++ b/src/components/Ethereum/AttestationsByEntity/AttestationsByEntity.types.ts
@@ -1,0 +1,46 @@
+export interface EntityCountItem {
+  /**
+   * Entity name (e.g., staking provider name)
+   */
+  entity: string;
+  /**
+   * Count/value for this entity
+   */
+  count: number;
+}
+
+export interface AttestationsByEntityProps {
+  /**
+   * Entity data to display (already filtered and sorted)
+   */
+  data: EntityCountItem[];
+  /**
+   * Chart title
+   * @default "Attestations by Entity"
+   */
+  title?: string;
+  /**
+   * Optional subtitle (e.g., total count summary)
+   */
+  subtitle?: string;
+  /**
+   * Anchor ID for scroll navigation and popout
+   * @default "attestations-by-entity"
+   */
+  anchorId?: string;
+  /**
+   * Chart orientation
+   * @default "horizontal"
+   */
+  orientation?: 'horizontal' | 'vertical';
+  /**
+   * Bar width
+   * @default "60%"
+   */
+  barWidth?: string | number;
+  /**
+   * Empty state message
+   * @default "No data available"
+   */
+  emptyMessage?: string;
+}

--- a/src/components/Ethereum/AttestationsByEntity/index.ts
+++ b/src/components/Ethereum/AttestationsByEntity/index.ts
@@ -1,0 +1,2 @@
+export { AttestationsByEntity } from './AttestationsByEntity';
+export type { AttestationsByEntityProps, EntityCountItem } from './AttestationsByEntity.types';

--- a/src/pages/ethereum/slots/DetailPage.tsx
+++ b/src/pages/ethereum/slots/DetailPage.tsx
@@ -12,6 +12,7 @@ import { SlotBasicInfoCard } from './components/SlotBasicInfoCard';
 import { AttestationArrivalsChart } from './components/AttestationArrivalsChart';
 import { AttestationParticipationCard } from './components/AttestationParticipationCard';
 import { AttestationHeadCorrectnessCard } from './components/AttestationHeadCorrectnessCard';
+import { AttestationsByEntity } from '@/components/Ethereum/AttestationsByEntity';
 import { BlockPropagationChart } from './components/BlockPropagationChart';
 import { BlobPropagationChart } from './components/BlobPropagationChart';
 import { MevBiddingTimelineChart } from './components/MevBiddingTimelineChart';
@@ -138,6 +139,11 @@ export function DetailPage(): JSX.Element {
         }
       : null;
 
+  // Calculate total missed attestations for subtitle
+  const totalMissedAttestations = data.missedAttestations.reduce((sum, item) => sum + item.count, 0);
+  const missedAttestationsSubtitle =
+    totalMissedAttestations > 0 ? `${totalMissedAttestations.toLocaleString()} total missed attestations` : undefined;
+
   // Transform MEV bidding data for chart
   const mevBiddingData = data.mevBidding.map(item => ({
     chunk_slot_start_diff: item.chunk_slot_start_diff ?? 0,
@@ -201,6 +207,13 @@ export function DetailPage(): JSX.Element {
           />
           <AttestationParticipationCard correctnessData={attestationCorrectnessData} />
           <AttestationHeadCorrectnessCard correctnessData={attestationCorrectnessData} />
+          <AttestationsByEntity
+            data={data.missedAttestations}
+            title="Missed Attestations by Entity"
+            subtitle={missedAttestationsSubtitle}
+            anchorId="missed-attestations"
+            emptyMessage="No missed attestations for this slot"
+          />
         </div>
 
         {/* Block Propagation Section */}


### PR DESCRIPTION
Adds a new generic `AttestationsByEntity` component that displays the top 10 entities with missed attestations for a given slot. The component is designed to be reusable for any entity-based attestation metrics, but is used on the `/ethereum/slots/$slot` page initially.

<img width="1677" height="1294" alt="image" src="https://github.com/user-attachments/assets/12b5d603-e4e2-403d-9035-d1f058311478" />
