### PR TITLE
fix(epochs): fill missing epochs in offline validators chart

### DIFF
--- a/src/pages/ethereum/epochs/IndexPage.tsx
+++ b/src/pages/ethereum/epochs/IndexPage.tsx
@@ -25,6 +25,18 @@ export function IndexPage(): React.JSX.Element {
   const navigate = useNavigate();
   const { epochs, missedAttestationsByEntity, isLoading, error, currentEpoch } = useEpochsData();
 
+  // Calculate epoch range from all epochs data
+  const epochRange = useMemo(() => {
+    if (epochs.length === 0) {
+      return undefined;
+    }
+    const epochNumbers = epochs.map(e => e.epoch).sort((a, b) => a - b);
+    return {
+      min: epochNumbers[0],
+      max: epochNumbers[epochNumbers.length - 1],
+    };
+  }, [epochs]);
+
   // Format table data - show all 10 epochs
   const tableData = useMemo(() => {
     return epochs.map(epoch => {
@@ -136,6 +148,7 @@ export function IndexPage(): React.JSX.Element {
           missedAttestationsByEntity={missedAttestationsByEntity}
           topEntitiesCount={10}
           anchorId="offline-validators-chart"
+          epochRange={epochRange}
         />
       </div>
     </Container>

--- a/src/pages/ethereum/epochs/components/MissedAttestationsByEpochChart/MissedAttestationsByEpochChart.tsx
+++ b/src/pages/ethereum/epochs/components/MissedAttestationsByEpochChart/MissedAttestationsByEpochChart.tsx
@@ -19,6 +19,7 @@ export function MissedAttestationsByEpochChart({
   missedAttestationsByEntity,
   topEntitiesCount = 10,
   anchorId,
+  epochRange,
 }: MissedAttestationsByEpochChartProps): React.JSX.Element {
   // Calculate which entities to show (top N by total missed)
   const { topEntities, series, minEpoch, maxEpoch } = useMemo(() => {
@@ -40,10 +41,17 @@ export function MissedAttestationsByEpochChart({
       return { topEntities: [], series: [], minEpoch: 0, maxEpoch: 0 };
     }
 
-    // Get epoch range
-    const epochs = [...new Set(missedAttestationsByEntity.map(r => r.epoch))].sort((a, b) => a - b);
-    const minEpoch = epochs[0];
-    const maxEpoch = epochs[epochs.length - 1];
+    // Get epoch range - use provided range or fall back to data range
+    let minEpoch: number;
+    let maxEpoch: number;
+    if (epochRange) {
+      minEpoch = epochRange.min;
+      maxEpoch = epochRange.max;
+    } else {
+      const epochs = [...new Set(missedAttestationsByEntity.map(r => r.epoch))].sort((a, b) => a - b);
+      minEpoch = epochs[0];
+      maxEpoch = epochs[epochs.length - 1];
+    }
 
     // Build series data for each entity
     // Create a map of entity -> epoch -> count
@@ -84,7 +92,7 @@ export function MissedAttestationsByEpochChart({
       minEpoch,
       maxEpoch,
     };
-  }, [missedAttestationsByEntity, topEntitiesCount]);
+  }, [missedAttestationsByEntity, topEntitiesCount, epochRange]);
 
   // Calculate total missed for subtitle
   const totalMissed = missedAttestationsByEntity.reduce((sum, record) => sum + record.count, 0);

--- a/src/pages/ethereum/epochs/components/MissedAttestationsByEpochChart/MissedAttestationsByEpochChart.types.ts
+++ b/src/pages/ethereum/epochs/components/MissedAttestationsByEpochChart/MissedAttestationsByEpochChart.types.ts
@@ -10,4 +10,6 @@ export interface MissedAttestationsByEpochChartProps {
   topEntitiesCount?: number;
   /** Anchor ID for deep linking to this chart */
   anchorId?: string;
+  /** Expected epoch range to display (min and max epoch numbers) */
+  epochRange?: { min: number; max: number };
 }


### PR DESCRIPTION
## Summary
Fixes the **Offline Validators** chart to properly display all epochs in the fetched range, filling in missing data points with 0 instead of creating gaps in the timeline.

## Problem
Previously, the chart only plotted epochs where missed attestations existed in the API response. If an entity had no missed attestations in certain epochs, those epochs were completely missing from the chart, creating gaps in the visualization.

## Solution
- Added `epochRange` prop to `MissedAttestationsByEpochChart` to specify the full epoch range to display
- Updated chart logic to use the provided epoch range when available, falling back to data range
- Modified `IndexPage` to calculate and pass the epoch range from all fetched epoch data (always 10 consecutive epochs)
- Chart now iterates through the full epoch range and fills missing data points with 0

## Changes
- `src/pages/ethereum/epochs/components/MissedAttestationsByEpochChart/MissedAttestationsByEpochChart.types.ts` - Added `epochRange` prop
- `src/pages/ethereum/epochs/components/MissedAttestationsByEpochChart/MissedAttestationsByEpochChart.tsx` - Implemented epoch range logic
- `src/pages/ethereum/epochs/IndexPage.tsx` - Calculate and pass epoch range to chart

## Result
The chart now displays a continuous timeline across all 10 fetched epochs, with entities showing 0 missed attestations for epochs where they had no data.

## Test plan
- [ ] View the Epochs page at `/ethereum/epochs`
- [ ] Verify the "Offline Validators" chart shows a continuous timeline
- [ ] Confirm no gaps exist in the chart even when entities have epochs with no missed attestations
- [ ] Check that epochs with 0 missed attestations are correctly represented