### PR TITLE
feat: add block seen indicator to slot detail page

### DIFF
--- a/src/pages/ethereum/slots/components/SlotBasicInfoCard/SlotBasicInfoCard.tsx
+++ b/src/pages/ethereum/slots/components/SlotBasicInfoCard/SlotBasicInfoCard.tsx
@@ -16,6 +16,9 @@ export function SlotBasicInfoCard({ slot, epoch, data }: SlotBasicInfoCardProps)
   const blobCount = data.blobCount[0];
   const proposerEntity = data.proposerEntity[0];
 
+  // Determine if block was seen by monitoring infrastructure
+  const wasBlockSeen = !!blockHead;
+
   // Determine slot status from proposer data (which has canonical/orphaned/missed status)
   const getSlotStatus = (): { label: string; color: 'green' | 'red' | 'yellow' } => {
     const statusValue = blockProposer?.status?.toLowerCase();
@@ -61,9 +64,14 @@ export function SlotBasicInfoCard({ slot, epoch, data }: SlotBasicInfoCardProps)
       header={
         <div className="flex items-center justify-between">
           <h2 className="text-lg/7 font-semibold text-foreground">Slot Information</h2>
-          <Badge color={status.color} variant="border">
-            {status.label}
-          </Badge>
+          <div className="flex items-center gap-2">
+            <Badge color={wasBlockSeen ? 'green' : 'red'} variant="border">
+              {wasBlockSeen ? 'Block Seen' : 'Block Not Seen'}
+            </Badge>
+            <Badge color={status.color} variant="border">
+              {status.label}
+            </Badge>
+          </div>
         </div>
       }
     >


### PR DESCRIPTION
## Summary
- Add visual indicator showing whether a block was observed by the monitoring infrastructure
- Display green "Block Seen" badge when blockHead data exists
- Display red "Block Not Seen" badge when no block data was captured
- Helps users distinguish between blocks that were not produced versus blocks that were produced but not observed by Xatu

## Changes
- Updated `SlotBasicInfoCard` component to include block seen status
- Added badge next to existing status badge (Canonical/Orphaned/Missed)

## Test plan
- [x] Build succeeds without errors
- [ ] Verify badge appears correctly on slot detail page for seen blocks
- [ ] Verify badge appears correctly on slot detail page for unseen blocks
- [ ] Check responsive layout on mobile/tablet/desktop