### PR TITLE
chore: cleanup chart tests and migrate to ECharts v6 APIs

### DIFF
--- a/.storybook/vitest-setup.ts
+++ b/.storybook/vitest-setup.ts
@@ -1,5 +1,32 @@
 import '@testing-library/jest-dom';
+import { beforeAll, vi } from 'vitest';
 import { setProjectAnnotations } from '@storybook/react-vite';
 import * as projectAnnotations from './preview';
 
 setProjectAnnotations([projectAnnotations]);
+
+// Setup mocks for ECharts v6 test environment
+beforeAll(() => {
+  // Mock DOM dimensions for ECharts (jsdom doesn't compute actual dimensions)
+  // This fixes "Can't get DOM width or height" warnings in tests
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    value: 800,
+  });
+
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    value: 600,
+  });
+
+  // Mock ResizeObserver for ECharts and echarts-for-react
+  // This fixes "Cannot read properties of undefined (reading 'disconnect')" errors
+  // Using regular function constructor (not arrow function) for proper instantiation
+  const ResizeObserverMock = vi.fn(function (this: ResizeObserver) {
+    this.observe = vi.fn();
+    this.unobserve = vi.fn();
+    this.disconnect = vi.fn();
+  });
+
+  vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build --mode production",
     "preview": "vite preview",
-    "test": "vitest run --no-ui --passWithNoTests",
+    "test": "pnpm test:unit && pnpm test:storybook",
     "test:unit": "vitest run --no-ui --config vitest.config.unit.ts",
     "test:unit:watch": "vitest --no-ui --config vitest.config.unit.ts",
     "test:storybook": "vitest run --no-ui --config vitest.config.ts",

--- a/src/components/Charts/Bar/Bar.tsx
+++ b/src/components/Charts/Bar/Bar.tsx
@@ -156,7 +156,9 @@ export function BarChart({
         right: 10,
         bottom: 30,
         left: 10,
-        containLabel: true,
+        // ECharts v6: use outerBounds instead of deprecated containLabel
+        outerBoundsMode: 'same' as const,
+        outerBoundsContain: 'axisLabel' as const,
       },
       xAxis: isHorizontal ? valueAxisConfig : categoryAxisConfig,
       yAxis: isHorizontal ? categoryAxisConfig : valueAxisConfig,

--- a/src/components/Charts/BoxPlot/BoxPlot.tsx
+++ b/src/components/Charts/BoxPlot/BoxPlot.tsx
@@ -148,7 +148,9 @@ export function BoxPlot({
       legend: legendConfig,
       grid: {
         ...getGridPadding(),
-        containLabel: true,
+        // ECharts v6: use outerBounds instead of deprecated containLabel
+        outerBoundsMode: 'same' as const,
+        outerBoundsContain: 'axisLabel' as const,
       },
       xAxis: {
         type: 'category' as const,

--- a/src/components/Charts/Heatmap/Heatmap.tsx
+++ b/src/components/Charts/Heatmap/Heatmap.tsx
@@ -6,6 +6,7 @@ import { GridComponent, TooltipComponent, TitleComponent, VisualMapComponent } f
 import { CanvasRenderer } from 'echarts/renderers';
 import colors from 'tailwindcss/colors';
 import { useThemeColors } from '@/hooks/useThemeColors';
+import { resolveCssColorToHex } from '@/utils/color';
 import type { HeatmapChartProps } from './Heatmap.types';
 
 // Register ECharts components
@@ -48,6 +49,9 @@ export function HeatmapChart({
 }: HeatmapChartProps): React.JSX.Element {
   const themeColors = useThemeColors();
 
+  // Convert OKLCH colors (from Tailwind v4) to hex format for ECharts compatibility
+  const convertedColorGradient = colorGradient.map(color => resolveCssColorToHex(color));
+
   const option = {
     animation: true,
     animationDuration,
@@ -69,7 +73,9 @@ export function HeatmapChart({
       right: showVisualMap ? 90 : 16,
       bottom: 28,
       left: 64,
-      containLabel: true,
+      // ECharts v6: use outerBounds instead of deprecated containLabel
+      outerBoundsMode: 'same' as const,
+      outerBoundsContain: 'axisLabel' as const,
     },
     xAxis: {
       type: 'category',
@@ -145,7 +151,7 @@ export function HeatmapChart({
             top: 'center',
             show: showVisualMap,
             inRange: {
-              color: colorGradient,
+              color: convertedColorGradient,
             },
             textStyle: {
               color: themeColors.foreground,

--- a/src/components/Charts/Line/Line.tsx
+++ b/src/components/Charts/Line/Line.tsx
@@ -4,7 +4,7 @@ import * as echarts from 'echarts/core';
 import { LineChart as EChartsLine } from 'echarts/charts';
 import { GridComponent, TooltipComponent, TitleComponent } from 'echarts/components';
 import { CanvasRenderer } from 'echarts/renderers';
-import { hexToRgba } from '@/utils';
+import { hexToRgba, resolveCssColorToHex } from '@/utils';
 import { useThemeColors } from '@/hooks/useThemeColors';
 import type { LineChartProps } from './Line.types';
 
@@ -47,6 +47,9 @@ export function LineChart({
 }: LineChartProps): JSX.Element {
   const themeColors = useThemeColors();
 
+  // Convert OKLCH colors (from Tailwind v4) to hex format for ECharts compatibility
+  const convertedColor = color ? resolveCssColorToHex(color) : undefined;
+
   const option = useMemo(
     () => ({
       animation: true,
@@ -70,7 +73,9 @@ export function LineChart({
         right: undefined,
         bottom: xAxisTitle ? 50 : 30,
         left: yAxisTitle ? 60 : 8,
-        containLabel: true,
+        // ECharts v6: use outerBounds instead of deprecated containLabel
+        outerBoundsMode: 'same' as const,
+        outerBoundsContain: 'axisLabel' as const,
       },
       xAxis: {
         type: 'category',
@@ -131,7 +136,7 @@ export function LineChart({
           symbol: 'none',
           showSymbol: false,
           lineStyle: {
-            color: color || themeColors.primary,
+            color: convertedColor || themeColors.primary,
             width: 3,
           },
           areaStyle: showArea
@@ -145,11 +150,11 @@ export function LineChart({
                   colorStops: [
                     {
                       offset: 0,
-                      color: hexToRgba(color || themeColors.primary, 0.5),
+                      color: hexToRgba(convertedColor || themeColors.primary, 0.5),
                     },
                     {
                       offset: 1,
-                      color: hexToRgba(color || themeColors.primary, 0.06),
+                      color: hexToRgba(convertedColor || themeColors.primary, 0.06),
                     },
                   ],
                 },
@@ -191,7 +196,7 @@ export function LineChart({
       titleTop,
       smooth,
       showArea,
-      color,
+      convertedColor,
       yMax,
       xMax,
       connectNulls,

--- a/src/components/Charts/Map/Map.tsx
+++ b/src/components/Charts/Map/Map.tsx
@@ -3,10 +3,16 @@ import { useState, useEffect, useMemo } from 'react';
 import ReactECharts from 'echarts-for-react';
 import type { ECharts } from 'echarts';
 import * as echarts from 'echarts';
-import 'echarts-gl';
+// Use selective imports to avoid "geo3D exists" warning (ECharts v6 + echarts-gl)
+import { Lines3DChart, Scatter3DChart } from 'echarts-gl/charts';
+import { Geo3DComponent } from 'echarts-gl/components';
 import type { MapChartProps } from './Map.types';
 import { useThemeColors } from '@/hooks/useThemeColors';
 import { useTheme } from '@/hooks/useTheme';
+import { resolveCssColorToHex } from '@/utils/color';
+
+// Register echarts-gl components selectively to prevent duplicate registration
+echarts.use([Lines3DChart, Scatter3DChart, Geo3DComponent]);
 
 /**
  * MapChart - A 3D map visualization component using ECharts GL
@@ -44,6 +50,12 @@ export function MapChart({
   const { theme } = useTheme();
   const [echartsInstance, setEchartsInstance] = useState<ECharts | null>(null);
   const [mapLoaded, setMapLoaded] = useState(false);
+
+  // Convert OKLCH colors (from Tailwind v4) to hex format for ECharts compatibility
+  const convertedLineColor = lineColor ? resolveCssColorToHex(lineColor) : undefined;
+  const convertedMapColor = mapColor ? resolveCssColorToHex(mapColor) : undefined;
+  const convertedEnvironment = environment ? resolveCssColorToHex(environment) : undefined;
+  const convertedPointColor = pointColor ? resolveCssColorToHex(pointColor) : undefined;
 
   // Load and register world map on mount
   useEffect(() => {
@@ -101,7 +113,7 @@ export function MapChart({
         blendMode: 'lighter',
         lineStyle: {
           width: 0.2,
-          color: lineColor || themeColors.primary,
+          color: convertedLineColor || themeColors.primary,
           opacity: 0.05,
         },
         data: routeData,
@@ -116,7 +128,7 @@ export function MapChart({
         symbol: 'circle',
         symbolSize: pointSize,
         itemStyle: {
-          color: pointColor || themeColors.primary,
+          color: convertedPointColor || themeColors.primary,
           opacity: 0.8,
         },
         label: {
@@ -132,7 +144,7 @@ export function MapChart({
     }
 
     return {
-      backgroundColor: environment || themeColors.background,
+      backgroundColor: convertedEnvironment || themeColors.background,
       tooltip: {
         show: true,
         formatter: (params: Record<string, unknown>) => {
@@ -168,7 +180,7 @@ export function MapChart({
         map: 'world',
         shading: 'realistic',
         silent: true,
-        environment: environment || themeColors.background,
+        environment: convertedEnvironment || themeColors.background,
         realisticMaterial: {
           roughness: 0.8,
           metalness: 0,
@@ -199,7 +211,7 @@ export function MapChart({
           zoomSensitivity: 1,
         },
         itemStyle: {
-          color: mapColor || themeColors.muted,
+          color: convertedMapColor || themeColors.muted,
         },
         regionHeight: regionHeight,
       },
@@ -210,11 +222,11 @@ export function MapChart({
     points,
     title,
     showEffect,
-    environment,
-    lineColor,
-    pointColor,
+    convertedEnvironment,
+    convertedLineColor,
+    convertedPointColor,
     pointSize,
-    mapColor,
+    convertedMapColor,
     distance,
     alpha,
     regionHeight,

--- a/src/components/Charts/ScatterAndLine/ScatterAndLine.tsx
+++ b/src/components/Charts/ScatterAndLine/ScatterAndLine.tsx
@@ -79,7 +79,9 @@ export function ScatterAndLineChart({
         right: yAxis2Title ? 80 : 24,
         bottom: showLegend && legendPosition === 'bottom' ? 80 : 48,
         left: 64,
-        containLabel: true,
+        // ECharts v6: use outerBounds instead of deprecated containLabel
+        outerBoundsMode: 'same' as const,
+        outerBoundsContain: 'axisLabel' as const,
       },
       xAxis: {
         type: 'value' as const,

--- a/src/components/Ethereum/SlotProgressTimeline/SlotProgressTimeline.tsx
+++ b/src/components/Ethereum/SlotProgressTimeline/SlotProgressTimeline.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react';
+import React, { type JSX } from 'react';
 import { useMemo } from 'react';
 import clsx from 'clsx';
 import type { SlotProgressTimelineProps, PhaseData } from './SlotProgressTimeline.types';
@@ -164,9 +164,9 @@ export function SlotProgressTimeline({
               mode === 'live' && connectionProgress[index] > 0 && connectionProgress[index] < 100;
 
             return (
-              <>
+              <React.Fragment key={phase.id}>
                 {/* Phase node */}
-                <div key={phase.id} className="shrink-0">
+                <div className="shrink-0">
                   <PhaseNode
                     phase={phase}
                     status={status}
@@ -177,7 +177,7 @@ export function SlotProgressTimeline({
 
                 {/* Connection to next phase */}
                 {hasConnection && (
-                  <div key={`connection-${phase.id}`} className="mx-4 flex-1">
+                  <div className="mx-4 flex-1">
                     <PhaseConnection
                       progress={connectionProgress[index]}
                       orientation="horizontal"
@@ -185,7 +185,7 @@ export function SlotProgressTimeline({
                     />
                   </div>
                 )}
-              </>
+              </React.Fragment>
             );
           })}
         </div>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,18 @@
 /// <reference types="vite/client" />
+
+// Type declarations for echarts-gl selective imports
+// echarts-gl doesn't provide individual module types, so we declare them here
+// Using EChartsExtension from echarts/core as the proper type
+declare module 'echarts-gl/charts' {
+  import type { EChartsExtension } from 'echarts/core';
+  export const Lines3DChart: EChartsExtension;
+  export const Scatter3DChart: EChartsExtension;
+  export const Map3DChart: EChartsExtension;
+}
+
+declare module 'echarts-gl/components' {
+  import type { EChartsExtension } from 'echarts/core';
+  export const GlobeComponent: EChartsExtension;
+  export const Geo3DComponent: EChartsExtension;
+  export const Grid3DComponent: EChartsExtension;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,10 +7,11 @@ import path from 'path';
 /**
  * Vitest v4 config for Storybook tests
  *
- * The storybookTest plugin MUST be at the root plugins level, not nested inside
- * test.projects (known Storybook limitation with @storybook/addon-vitest).
+ * The storybookTest plugin MUST be at the root plugins level, and when used,
+ * it affects the entire config. Therefore, we need separate configs for unit
+ * and storybook tests in Vitest v4.
  *
- * Run via: pnpm test:storybook
+ * Run via: pnpm test:storybook or pnpm test (default)
  * For unit tests, see vitest.config.unit.ts
  */
 export default defineConfig({
@@ -26,11 +27,8 @@ export default defineConfig({
     environment: 'jsdom',
     browser: {
       enabled: true,
-      provider: playwright({
-        launch: {
-          headless: true,
-        },
-      }),
+      headless: true,
+      provider: playwright(),
       instances: [
         {
           browser: 'chromium',

--- a/vitest.config.unit.ts
+++ b/vitest.config.unit.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     environment: 'jsdom',
     include: ['src/**/*.test.{ts,tsx}'],
     exclude: ['src/**/*.stories.{ts,tsx}', 'node_modules'],
-    setupFiles: ['./.storybook/vitest-setup.ts'],
+    setupFiles: ['./vitest.setup.ts'],
     // Vitest 4: Explicitly configure fake timers to avoid queueMicrotask OOM issues
     // See: https://github.com/vitest-dev/vitest/issues/7288
     fakeTimers: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -12,4 +12,27 @@ beforeAll(() => {
     }
     originalWarn(...args);
   });
+
+  // Mock DOM dimensions for ECharts (jsdom doesn't compute actual dimensions)
+  // This fixes "Can't get DOM width or height" warnings in tests
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    value: 800,
+  });
+
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    value: 600,
+  });
+
+  // Mock ResizeObserver for ECharts and echarts-for-react
+  // This fixes "Cannot read properties of undefined (reading 'disconnect')" errors
+  // Using regular function constructor (not arrow function) for proper instantiation
+  const ResizeObserverMock = vi.fn(function (this: ResizeObserver) {
+    this.observe = vi.fn();
+    this.unobserve = vi.fn();
+    this.disconnect = vi.fn();
+  });
+
+  vi.stubGlobal('ResizeObserver', ResizeObserverMock);
 });


### PR DESCRIPTION
- Add comprehensive ECharts v6 test mocks (ResizeObserver, DOM dimensions)
- Migrate all chart components to use outerBounds instead of deprecated containLabel
- Add OKLCH to hex color conversion for Tailwind v4 compatibility
- Use selective echarts-gl imports to prevent duplicate registration warnings
- Separate unit and Storybook test configurations for Vitest v4
- Fix React key prop warning in SlotProgressTimeline
- Update test command to run both unit and Storybook tests