### PR TITLE
fix(epochs): correct offline attesters logic and improve table styling

### DIFF
--- a/src/pages/ethereum/epochs/IndexPage.tsx
+++ b/src/pages/ethereum/epochs/IndexPage.tsx
@@ -89,6 +89,7 @@ export function IndexPage(): React.JSX.Element {
 
       <div className="mt-6">
         <Table
+          variant="nested"
           data={tableData}
           columns={[
             {
@@ -134,7 +135,6 @@ export function IndexPage(): React.JSX.Element {
             },
           ]}
           onRowClick={handleRowClick}
-          getRowClassName={row => (row.isCurrent ? 'bg-primary/10 hover:bg-primary/20' : 'hover:bg-surface-hover')}
         />
 
         <div className="mt-4 text-sm text-muted">

--- a/src/pages/ethereum/epochs/hooks/useEpochsData.ts
+++ b/src/pages/ethereum/epochs/hooks/useEpochsData.ts
@@ -172,13 +172,12 @@ export function useEpochsData(): UseEpochsDataReturn {
       });
     });
 
-    // Convert to array format, filtering out entities with <= 5 missed attestations per epoch
+    // Convert to array format - include all missed attestations
+    // Chart component will handle filtering for top N entities by total sum
     const missedAttestationsByEntity: MissedAttestationByEntity[] = [];
     entityMap.forEach((epochMap, entity) => {
       epochMap.forEach((count, epoch) => {
-        if (count > 5) {
-          missedAttestationsByEntity.push({ entity, epoch, count });
-        }
+        missedAttestationsByEntity.push({ entity, epoch, count });
       });
     });
 


### PR DESCRIPTION
## Summary

- Fixes offline attesters to show top 10 based on sum over entire period instead of filtering per-epoch
- Removes custom table background styling to use default hover states
- Changes table variant to "nested" to remove extra padding
