### PR TITLE
feat: Add TanStack Router search params support to Storybook

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -23,6 +23,27 @@ initialize({
   },
 });
 
+/**
+ * Storybook Preview Configuration
+ *
+ * ## Router Configuration
+ *
+ * Stories can override the initial router state via `parameters.router`:
+ *
+ * @example
+ * ```tsx
+ * export const WithCustomNetwork: Story = {
+ *   parameters: {
+ *     router: {
+ *       initialUrl: '/',
+ *       initialSearch: { network: 'holesky' },
+ *     },
+ *   },
+ * };
+ * ```
+ *
+ * This allows testing components that depend on URL search params (e.g., network selection).
+ */
 const preview: Preview = {
   loaders: [mswLoader],
   decorators: [
@@ -61,6 +82,11 @@ const preview: Preview = {
         });
       }
 
+      // Allow stories to override initial URL and search params via parameters.router
+      const routerConfig = context.parameters.router || {};
+      const initialUrl = routerConfig.initialUrl || '/';
+      const initialSearch = routerConfig.initialSearch || {};
+
       // Create a root route that renders the Story inside NetworkProvider
       const rootRoute = createRootRoute({
         component: () => (
@@ -68,13 +94,21 @@ const preview: Preview = {
             <Story />
           </NetworkProvider>
         ),
+        // Enable search params validation
+        validateSearch: () => initialSearch,
       });
 
       // Create a router with memory history (no browser URL changes)
+      // Pass initial search params in the URL if provided
+      const searchString =
+        Object.keys(initialSearch).length > 0
+          ? '?' + new URLSearchParams(initialSearch as Record<string, string>).toString()
+          : '';
+
       const router = createRouter({
         routeTree: rootRoute,
         history: createMemoryHistory({
-          initialEntries: ['/'],
+          initialEntries: [initialUrl + searchString],
         }),
       });
 

--- a/src/components/Ethereum/NetworkSelect/NetworkSelect.stories.tsx
+++ b/src/components/Ethereum/NetworkSelect/NetworkSelect.stories.tsx
@@ -48,3 +48,36 @@ export const CustomLabel: Story = {
     label: 'Select Network',
   },
 };
+
+/**
+ * Network selector with Holesky pre-selected via URL params.
+ * This demonstrates how the network parameter can be set in the URL for shareable links.
+ */
+export const WithHoleskySelected: Story = {
+  args: {
+    showLabel: true,
+    label: 'Network',
+  },
+  parameters: {
+    router: {
+      initialUrl: '/',
+      initialSearch: { network: 'holesky' },
+    },
+  },
+};
+
+/**
+ * Network selector with Sepolia pre-selected via URL params.
+ */
+export const WithSepoliaSelected: Story = {
+  args: {
+    showLabel: true,
+    label: 'Network',
+  },
+  parameters: {
+    router: {
+      initialUrl: '/',
+      initialSearch: { network: 'sepolia' },
+    },
+  },
+};


### PR DESCRIPTION
Update Storybook configuration to properly support URL search parameters with TanStack Router, enabling network selection via URL params in stories.

Changes:
- Add parameters.router configuration support for stories
- Stories can now specify initialUrl and initialSearch
- Memory router properly passes search params in query string
- Add validateSearch to root route for search param parsing
- Add example stories demonstrating network param configuration

This aligns with the NetworkProvider changes that moved from localStorage to URL-based network selection for shareable links.