### PR TITLE
fix: improve mobile responsiveness for ConfigGate component

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html lang="en" itemscope="" itemtype="http://schema.org/Webpage">
   <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0" />
     <style>
       /* Critical CSS - Inline for instant rendering */
       body:not(.react-loaded) * {

--- a/src/components/Overlays/ConfigGate/ConfigGate.tsx
+++ b/src/components/Overlays/ConfigGate/ConfigGate.tsx
@@ -24,10 +24,14 @@ export function ConfigGate({ children }: ConfigGateProps): JSX.Element {
         </div>
 
         {/* Content */}
-        <div className="relative flex flex-col items-center">
-          <img src="/images/lab.png" className="size-72 animate-spin object-contain" alt="Loading..." />
-          <p className="mt-8 text-2xl font-semibold text-foreground">Loading Lab...</p>
-          <div className="mt-4 h-1 w-32 animate-pulse rounded-full bg-linear-to-r from-primary to-accent"></div>
+        <div className="relative flex flex-col items-center px-4">
+          <img
+            src="/images/lab.png"
+            className="size-48 animate-spin object-contain sm:size-64 md:size-72"
+            alt="Loading..."
+          />
+          <p className="mt-6 text-xl font-semibold text-foreground sm:mt-8 sm:text-2xl">Loading Lab...</p>
+          <div className="mt-3 h-1 w-24 animate-pulse rounded-full bg-linear-to-r from-primary to-accent sm:mt-4 sm:w-32"></div>
         </div>
       </div>
     );
@@ -45,17 +49,21 @@ export function ConfigGate({ children }: ConfigGateProps): JSX.Element {
         </div>
 
         {/* Content */}
-        <div className="relative flex flex-col items-center">
+        <div className="relative flex flex-col items-center px-4">
           <div className="relative">
             {/* Glow effect */}
             <div className="absolute inset-0 animate-pulse rounded-full bg-danger/20 blur-3xl"></div>
-            <img src="/images/lab.png" className="relative size-72 rotate-180 object-contain" alt="Lab Logo" />
+            <img
+              src="/images/lab.png"
+              className="relative size-48 rotate-180 object-contain sm:size-64 md:size-72"
+              alt="Lab Logo"
+            />
           </div>
-          <h1 className="mt-8 text-2xl font-bold text-danger">Failed to Load Configuration</h1>
+          <h1 className="mt-6 text-xl font-bold text-danger sm:mt-8 sm:text-2xl">Failed to Load Configuration</h1>
           {error && <p className="mt-2 max-w-md text-center text-sm text-muted">{error.message}</p>}
           <button
             onClick={() => window.location.reload()}
-            className="mt-8 rounded-lg bg-danger px-6 py-2.5 text-sm font-semibold text-white shadow-sm transition-all hover:bg-danger/90 hover:shadow-md active:scale-95"
+            className="mt-6 rounded-lg bg-danger px-6 py-2.5 text-sm font-semibold text-white shadow-sm transition-all hover:bg-danger/90 hover:shadow-md active:scale-95 sm:mt-8"
           >
             Reload Page
           </button>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -106,8 +106,7 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
       { httpEquiv: 'X-UA-Compatible', content: 'IE=edge' },
       {
         name: 'viewport',
-        content:
-          'width=device-width, height=device-height, initial-scale=1.0, user-scalable=no, maximum-scale=1.0, minimal-ui',
+        content: 'width=device-width, initial-scale=1.0, maximum-scale=5.0',
       },
       { name: 'description', content: 'Experimental platform for exploring Ethereum data and network statistics.' },
 


### PR DESCRIPTION
- Make ConfigGate image responsive across mobile, tablet, and desktop
  - Mobile (<640px): size-48 (192px)
  - Tablet (≥640px): size-64 (256px)
  - Desktop (≥768px): size-72 (288px)
- Add responsive text sizing and spacing for mobile viewports
- Add horizontal padding to prevent edge-to-edge content
- Add viewport meta tag to index.html for immediate application
- Update viewport meta tags to allow user zoom (accessibility)
- Remove restrictive user-scalable=no and maximum-scale=1.0
- Fix potential layout issues on small screens (320px iPhone SE)