### PR TITLE
Fix conductor run script port detection and logging

### DIFF
--- a/conductor-run.sh
+++ b/conductor-run.sh
@@ -15,7 +15,7 @@ find_available_port() {
 }
 
 # Determine ports
-VITE_PORT=${PORT:-5173}
+VITE_PORT=$(find_available_port 5173)
 STORYBOOK_PORT=$(find_available_port 6006)
 
 # Function to cleanup on exit
@@ -30,27 +30,70 @@ cleanup() {
 # Trap SIGINT and SIGTERM
 trap cleanup SIGINT SIGTERM
 
+# Create log files for capturing output
+VITE_LOG=$(mktemp)
+STORYBOOK_LOG=$(mktemp)
+
 # Start Vite dev server in background
-echo "📦 Starting Vite dev server on port $VITE_PORT..."
-pnpm dev &
+echo "📦 Starting Vite dev server..."
+PORT=$VITE_PORT pnpm dev > "$VITE_LOG" 2>&1 &
 VITE_PID=$!
 
-# Start Storybook in background (using storybook CLI directly to override port)
-echo "📚 Starting Storybook on port $STORYBOOK_PORT..."
-pnpm exec storybook dev -p $STORYBOOK_PORT --no-open &
+# Start Storybook in background
+echo "📚 Starting Storybook..."
+pnpm exec storybook dev -p $STORYBOOK_PORT --no-open > "$STORYBOOK_LOG" 2>&1 &
 STORYBOOK_PID=$!
 
-# Wait a moment for servers to start
-sleep 2
+# Wait for servers to be ready and capture their ports
+echo "⏳ Waiting for servers to start..."
+
+# Wait for Vite to output its port
+ACTUAL_VITE_PORT=""
+for i in {1..30}; do
+    if [ -f "$VITE_LOG" ]; then
+        ACTUAL_VITE_PORT=$(grep -oE "http://localhost:[0-9]+" "$VITE_LOG" | grep -oE "[0-9]+" | head -1)
+        if [ -n "$ACTUAL_VITE_PORT" ]; then
+            break
+        fi
+    fi
+    sleep 0.2
+done
+
+# Wait for Storybook to output its port
+ACTUAL_STORYBOOK_PORT=""
+for i in {1..30}; do
+    if [ -f "$STORYBOOK_LOG" ]; then
+        ACTUAL_STORYBOOK_PORT=$(grep -oE "Local:.*http://localhost:[0-9]+" "$STORYBOOK_LOG" | grep -oE "[0-9]+" | head -1)
+        if [ -n "$ACTUAL_STORYBOOK_PORT" ]; then
+            break
+        fi
+    fi
+    sleep 0.2
+done
+
+# Fallback to expected ports if detection failed
+ACTUAL_VITE_PORT=${ACTUAL_VITE_PORT:-$VITE_PORT}
+ACTUAL_STORYBOOK_PORT=${ACTUAL_STORYBOOK_PORT:-$STORYBOOK_PORT}
 
 echo ""
 echo "✅ Both servers are running!"
 echo ""
-echo "   📦 Frontend:   http://localhost:$VITE_PORT"
-echo "   📚 Storybook:  http://localhost:$STORYBOOK_PORT"
+echo "   📦 Frontend:   http://localhost:$ACTUAL_VITE_PORT"
+echo "   📚 Storybook:  http://localhost:$ACTUAL_STORYBOOK_PORT"
 echo ""
 echo "Press Ctrl+C to stop both servers"
 echo ""
 
+# Cleanup temp log files on exit
+cleanup_logs() {
+    rm -f "$VITE_LOG" "$STORYBOOK_LOG"
+    kill $TAIL_PID 2>/dev/null || true
+}
+trap "cleanup; cleanup_logs" SIGINT SIGTERM EXIT
+
+# Tail both log files to show output
+tail -f "$VITE_LOG" "$STORYBOOK_LOG" &
+TAIL_PID=$!
+
 # Wait for both processes
-wait
+wait $VITE_PID $STORYBOOK_PID


### PR DESCRIPTION
## Summary

Fixed the conductor run script to properly detect and display the actual ports used by Vite and Storybook servers when they fall back to alternative ports due to conflicts.

## Changes

- Auto-detect available Vite port instead of hardcoding to 5173
- Parse server output to capture actual port numbers instead of relying on lsof
- Redirect server output to temp log files for cleaner display of startup information
- Add active polling with timeout for port detection (up to 6 seconds)
- Improve error handling with fallback to expected ports if detection fails
- Tail both server logs to show output in real-time
- Properly cleanup tail process and temp files on exit

## Testing

- Verified the script correctly detects ports when Vite falls back to 5175
- Verified the script correctly displays Storybook on its assigned port
- Tested server output is properly streamed to terminal