### PR TITLE
fix(layout): resolve mobile viewport scrolling issue with fixed header

### DIFF
--- a/src/pages/home/IndexPage.tsx
+++ b/src/pages/home/IndexPage.tsx
@@ -6,7 +6,7 @@ import { AlgorithmicArt } from './components/AlgorithmicArt';
 
 export function IndexPage(): JSX.Element {
   return (
-    <div className="relative h-screen overflow-hidden">
+    <div className="relative h-[calc(100dvh-65px)] overflow-hidden lg:h-screen">
       {/* Full-page Network Visualization - fills viewport */}
       <div className="absolute inset-0 z-0">
         <AlgorithmicArt height={typeof window !== 'undefined' ? window.innerHeight : 800} seed={12345} speed={1} />
@@ -14,7 +14,7 @@ export function IndexPage(): JSX.Element {
 
       {/* Content Layer - positioned on top of visualization */}
       <div className="absolute inset-0 z-20 overflow-y-auto">
-        <div className="flex min-h-screen flex-col px-4 pt-20 sm:pt-40">
+        <div className="flex min-h-full flex-col px-4 pt-20 sm:pt-40">
           {/* Hero Section - centered and spacious */}
           <div className="mb-16 flex flex-col items-center text-center sm:mb-48">
             {/* Main Title - matching sidebar style */}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -121,12 +121,12 @@ function RootComponent(): JSX.Element {
           <ConfigGate>
             <NetworkProvider>
               <HeadContent />
-              <div className="min-h-dvh bg-background">
+              <div className="bg-background">
                 {/* Sidebar (mobile + desktop) */}
                 <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
 
                 {/* Mobile header */}
-                <div className="sticky top-0 z-40 flex items-center justify-between border-b border-border bg-surface/95 px-4 py-4 shadow-sm backdrop-blur-xl sm:px-6 lg:hidden">
+                <div className="fixed top-0 right-0 left-0 z-40 flex items-center justify-between border-b border-border bg-surface/95 px-4 py-4 shadow-sm backdrop-blur-xl sm:px-6 lg:hidden">
                   <div className="flex items-center gap-x-6">
                     <button
                       type="button"
@@ -149,7 +149,7 @@ function RootComponent(): JSX.Element {
                 </div>
 
                 {/* Main content */}
-                <main className="bg-background lg:pl-72">
+                <main className="bg-background pt-[65px] lg:min-h-dvh lg:pt-0 lg:pl-72">
                   <FeatureGate>
                     <Outlet />
                   </FeatureGate>


### PR DESCRIPTION
Changed mobile header from sticky to fixed positioning to prevent unwanted vertical scroll. Adjusted main content padding and IndexPage height calculation to account for 65px fixed header on mobile while maintaining correct desktop layout with sidebar.

- src/routes/__root.tsx: Convert mobile header to fixed positioning
- src/pages/home/IndexPage.tsx: Use calc(100dvh - 65px) for mobile height