### PR TITLE
feat(Sidebar): close sidebar when network search param changes

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -98,7 +98,7 @@ function RootComponent(): JSX.Element {
       }
 
       // Close sidebar if the network search param changed or was removed
-      const currentNetwork = event.toLocation.search?.network;
+      const currentNetwork = (event.toLocation.search as Record<string, unknown>)?.network as string | undefined;
       if (currentNetwork !== previousNetwork) {
         setSidebarOpen(false);
         previousNetwork = currentNetwork;


### PR DESCRIPTION
Update the sidebar close logic to also trigger when the network search parameter changes or is removed, in addition to the existing path change behavior. This improves UX by auto-closing the mobile sidebar when users switch networks.