### PR TITLE
refactor: add emphasis prop for hover effects on multi-line / deep-link contributoors

### DIFF
--- a/src/components/Charts/MultiLine/MultiLine.stories.tsx
+++ b/src/components/Charts/MultiLine/MultiLine.stories.tsx
@@ -682,3 +682,56 @@ export const CustomTooltip: Story = {
     );
   },
 };
+
+/**
+ * Hover emphasis with small symbols that enlarge on hover
+ * Perfect for dense time series data - keeps charts clean while maintaining tooltip functionality
+ */
+export const EmphasisHover: Story = {
+  render: () => {
+    const themeColors = useThemeColors();
+    const palette = [themeColors.primary, themeColors.accent, '#10b981', '#f59e0b', '#8b5cf6'];
+
+    const startSlot = 1000;
+    const slotCount = 30;
+
+    return (
+      <MultiLineChart
+        series={Array.from({ length: 5 }, (_, nodeIdx) => ({
+          name: `Node ${nodeIdx + 1}`,
+          data: Array.from({ length: slotCount }, (_, slotIdx) => {
+            const slot = startSlot + slotIdx;
+            const baseLatency = 200 + nodeIdx * 20;
+            const variance = Math.sin(slotIdx * nodeIdx * 0.3) * 15;
+            return [slot, Math.round(baseLatency + variance)] as [number, number];
+          }),
+          color: palette[nodeIdx],
+          showSymbol: true,
+          symbolSize: 2,
+          lineWidth: 2,
+          emphasis: {
+            focus: 'series',
+            symbolSize: 6,
+          },
+        }))}
+        xAxis={{
+          type: 'value',
+          name: 'Slot',
+          min: startSlot,
+          max: startSlot + slotCount - 1,
+          formatter: (value: number | string) => value.toLocaleString(),
+        }}
+        yAxis={{
+          name: 'Latency (ms)',
+        }}
+        title="Hover Emphasis Example"
+        subtitle="Tiny symbols (size 2) enlarge to size 6 on hover with series highlighting"
+        showCard={true}
+        showLegend={true}
+        enableDataZoom={true}
+        tooltipTrigger="item"
+        height={400}
+      />
+    );
+  },
+};

--- a/src/components/Charts/MultiLine/MultiLine.types.ts
+++ b/src/components/Charts/MultiLine/MultiLine.types.ts
@@ -81,6 +81,26 @@ export interface SeriesData {
    * @default false
    */
   showEndLabel?: boolean;
+  /**
+   * Emphasis configuration for hover effects
+   * Allows customizing how the series appears when hovered
+   */
+  emphasis?: {
+    /**
+     * Focus behavior when hovering
+     * - 'series': Highlights the entire series
+     * - 'self': Only highlights the hovered point
+     */
+    focus?: 'series' | 'self';
+    /**
+     * Show symbols when hovering (overrides showSymbol)
+     */
+    showSymbol?: boolean;
+    /**
+     * Symbol size when hovering (overrides symbolSize)
+     */
+    symbolSize?: number;
+  };
 }
 
 /**

--- a/src/pages/xatu/contributors/hooks/useLatencyChartData.ts
+++ b/src/pages/xatu/contributors/hooks/useLatencyChartData.ts
@@ -126,8 +126,12 @@ export function useLatencyChartSeries(data: unknown, dataKey: string): LatencyCh
         data: chartData,
         color: extendedPalette[index % extendedPalette.length],
         showSymbol: true,
-        symbolSize: 4,
+        symbolSize: 2,
         lineWidth: 2,
+        emphasis: {
+          focus: 'series',
+          symbolSize: 6,
+        },
       });
     });
 

--- a/src/pages/xatu/contributors/hooks/usePreAggregatedLatencyChartSeries.ts
+++ b/src/pages/xatu/contributors/hooks/usePreAggregatedLatencyChartSeries.ts
@@ -125,8 +125,12 @@ export function usePreAggregatedLatencyChartSeries(
         data: chartData,
         color: extendedPalette[index % extendedPalette.length],
         showSymbol: true,
-        symbolSize: 4,
+        symbolSize: 2,
         lineWidth: 2,
+        emphasis: {
+          focus: 'series',
+          symbolSize: 6,
+        },
       });
     });
 

--- a/src/pages/xatu/fork-readiness/components/ClientReadinessCard/ClientReadinessCard.tsx
+++ b/src/pages/xatu/fork-readiness/components/ClientReadinessCard/ClientReadinessCard.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from 'react';
+import { Link } from '@tanstack/react-router';
 import { Card } from '@/components/Layout/Card';
 import { ClientLogo } from '@/components/Ethereum/ClientLogo';
 import { Badge } from '@/components/Elements/Badge';
@@ -43,9 +44,19 @@ export function ClientReadinessCard({ data }: ClientReadinessCardProps): JSX.Ele
       <div className="mt-4 space-y-2 border-t border-border pt-4">
         {nodes.map(node => (
           <div key={node.nodeName} className="flex items-center gap-3 text-xs/5">
-            <span className="min-w-0 flex-1 truncate pr-8 font-mono text-foreground">
-              {formatNodeName(node.nodeName)}
-            </span>
+            {node.username ? (
+              <Link
+                to="/xatu/contributors/$id"
+                params={{ id: node.username }}
+                className="min-w-0 flex-1 truncate pr-8 font-mono text-primary hover:underline"
+              >
+                {formatNodeName(node.nodeName)}
+              </Link>
+            ) : (
+              <span className="min-w-0 flex-1 truncate pr-8 font-mono text-foreground">
+                {formatNodeName(node.nodeName)}
+              </span>
+            )}
             <span className="shrink-0">
               <Badge color={node.isReady ? 'green' : 'red'} variant="flat">
                 {node.version}

--- a/src/pages/xatu/fork-readiness/utils/fork-data-processor.ts
+++ b/src/pages/xatu/fork-readiness/utils/fork-data-processor.ts
@@ -55,6 +55,7 @@ function calculateClientReadiness(
 
     nodeStatuses.push({
       nodeName: node.meta_client_name || 'unknown',
+      username: node.username,
       version,
       isReady,
       classification: node.meta_consensus_implementation,

--- a/src/pages/xatu/fork-readiness/utils/fork-data-processor.types.ts
+++ b/src/pages/xatu/fork-readiness/utils/fork-data-processor.types.ts
@@ -11,6 +11,7 @@ export interface ClientReadinessData {
 
 export interface NodeReadinessStatus {
   nodeName: string; // meta_client_name
+  username?: string; // username for linking to contributor detail page
   version: string; // meta_client_version
   isReady: boolean;
   classification?: string;

--- a/src/pages/xatu/geographical-checklist/components/GeographicalListView/GeographicalListView.tsx
+++ b/src/pages/xatu/geographical-checklist/components/GeographicalListView/GeographicalListView.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from 'react';
+import { Link } from '@tanstack/react-router';
 import { Disclosure } from '@/components/Layout/Disclosure';
 import { Table } from '@/components/Lists/Table';
 import type { GeographicalListViewProps } from './GeographicalListView.types';
@@ -34,8 +35,17 @@ export function GeographicalListView({ continents, isLoading }: GeographicalList
     },
     {
       header: 'Username',
-      accessor: node => node.username || 'Unknown',
-      cellClassName: 'text-muted',
+      accessor: node => {
+        const username = node.username || 'Unknown';
+        if (username === 'Unknown') {
+          return <span className="text-muted">{username}</span>;
+        }
+        return (
+          <Link to="/xatu/contributors/$id" params={{ id: username }} className="text-primary hover:underline">
+            {username}
+          </Link>
+        );
+      },
     },
     {
       header: 'Classification',


### PR DESCRIPTION
refactor(MultiLineChart): move axis/grid/tooltip configs into useMemo
style(latency charts): shrink default symbol size from 4 to 2, enlarge on hover
feat(fork-readiness): link node names to contributor detail pages
feat(geographical-checklist): make usernames clickable links

<img width="682" height="518" alt="Screenshot 2025-11-01 at 08 15 46" src="https://github.com/user-attachments/assets/edecb575-9747-4830-a37a-b09532c8370a" />
<img width="686" height="529" alt="Screenshot 2025-11-01 at 08 15 41" src="https://github.com/user-attachments/assets/1e615564-5f01-4f41-b5b2-ac0413bdaa52" />
