### PR TITLE
fix: improve chart hover interaction for flat segments

### DIFF
--- a/src/components/Charts/Line/Line.tsx
+++ b/src/components/Charts/Line/Line.tsx
@@ -166,14 +166,23 @@ export const LineChart = forwardRef<ReactEChartsCore, LineChartProps>(function L
               }
             : undefined,
           emphasis: {
+            focus: 'series' as const,
+            showSymbol: true,
+            symbolSize: 8,
             lineStyle: {
               width: 4,
+            },
+            itemStyle: {
+              color: convertedColor || CHART_CATEGORICAL_COLORS[0],
+              borderColor: themeColors.background,
+              borderWidth: 2,
             },
           },
         },
       ],
       tooltip: {
         trigger: 'axis',
+        triggerOn: 'mousemove' as const,
         backgroundColor: themeColors.background,
         borderColor: themeColors.border,
         borderWidth: 1,
@@ -187,6 +196,7 @@ export const LineChart = forwardRef<ReactEChartsCore, LineChartProps>(function L
             color: themeColors.muted,
             type: 'dashed',
           },
+          snap: true,
         },
       },
     }),

--- a/src/components/Charts/MultiLine/MultiLine.tsx
+++ b/src/components/Charts/MultiLine/MultiLine.tsx
@@ -242,18 +242,26 @@ export function MultiLineChart({
         color: seriesColor,
       },
       // Add emphasis configuration for hover effects
-      ...(s.emphasis
+      // Auto-enable symbol display on hover for better interactivity (especially important for step charts)
+      emphasis: s.emphasis
         ? {
-            emphasis: {
-              focus: s.emphasis.focus,
-              itemStyle: {
-                color: seriesColor,
-              },
-              ...(s.emphasis.showSymbol !== undefined ? { showSymbol: s.emphasis.showSymbol } : {}),
-              ...(s.emphasis.symbolSize !== undefined ? { symbolSize: s.emphasis.symbolSize } : {}),
+            focus: s.emphasis.focus,
+            itemStyle: {
+              color: seriesColor,
             },
+            ...(s.emphasis.showSymbol !== undefined ? { showSymbol: s.emphasis.showSymbol } : {}),
+            ...(s.emphasis.symbolSize !== undefined ? { symbolSize: s.emphasis.symbolSize } : {}),
           }
-        : {}),
+        : {
+            focus: 'series' as const,
+            showSymbol: true,
+            symbolSize: 8,
+            itemStyle: {
+              color: seriesColor,
+              borderColor: themeColors.background,
+              borderWidth: 2,
+            },
+          },
       // Add label at the right side of the chart if requested
       ...(s.showEndLabel
         ? {
@@ -454,6 +462,7 @@ export function MultiLineChart({
     // Build tooltip configuration
     const tooltipConfig = {
       trigger: tooltipTrigger,
+      triggerOn: 'mousemove' as const, // Enable fine-grained mousemove tracking for step charts
       backgroundColor: themeColors.surface,
       borderColor: themeColors.border,
       borderWidth: 1,
@@ -469,6 +478,7 @@ export function MultiLineChart({
                 color: themeColors.muted,
                 type: 'dashed' as const,
               },
+              snap: true, // Snap to data points for better step chart interaction
             }
           : undefined,
       formatter: tooltipFormatter || defaultTooltipFormatter,

--- a/src/components/Charts/ScatterAndLine/ScatterAndLine.tsx
+++ b/src/components/Charts/ScatterAndLine/ScatterAndLine.tsx
@@ -182,6 +182,7 @@ export function ScatterAndLineChart({
       ],
       tooltip: {
         trigger: tooltipTrigger,
+        triggerOn: 'mousemove' as const,
         backgroundColor: themeColors.background,
         borderColor: themeColors.border,
         borderWidth: 1,
@@ -189,6 +190,17 @@ export function ScatterAndLineChart({
           color: themeColors.foreground,
           fontSize: 12,
         },
+        axisPointer:
+          tooltipTrigger === 'axis'
+            ? {
+                type: 'line' as const,
+                lineStyle: {
+                  color: themeColors.muted,
+                  type: 'dashed' as const,
+                },
+                snap: true,
+              }
+            : undefined,
         formatter: tooltipFormatter,
       },
       legend: showLegend
@@ -231,31 +243,39 @@ export function ScatterAndLineChart({
           z: s.z,
         })),
         // Line series
-        ...lineSeries.map((s, index) => ({
-          name: s.name,
-          data: s.data,
-          type: 'line' as const,
-          smooth: s.smooth ?? true,
-          symbol: s.symbol ?? 'none',
-          symbolSize: s.symbolSize ?? 4,
-          lineStyle: {
-            color: s.color ?? getSeriesColor(scatterSeries.length + index),
-            width: s.lineWidth ?? 3,
-          },
-          itemStyle: {
-            color: s.color ?? getSeriesColor(scatterSeries.length + index),
-          },
-          emphasis:
-            s.symbol && s.symbol !== 'none'
-              ? {
-                  lineStyle: {
-                    width: (s.lineWidth ?? 3) + 1,
-                  },
-                }
-              : undefined,
-          yAxisIndex: s.yAxisIndex ?? 0,
-          z: s.z,
-        })),
+        ...lineSeries.map((s, index) => {
+          const lineColor = s.color ?? getSeriesColor(scatterSeries.length + index);
+          return {
+            name: s.name,
+            data: s.data,
+            type: 'line' as const,
+            smooth: s.smooth ?? true,
+            symbol: s.symbol ?? 'none',
+            symbolSize: s.symbolSize ?? 4,
+            lineStyle: {
+              color: lineColor,
+              width: s.lineWidth ?? 3,
+            },
+            itemStyle: {
+              color: lineColor,
+            },
+            emphasis: {
+              focus: 'series' as const,
+              showSymbol: true,
+              symbolSize: 8,
+              lineStyle: {
+                width: (s.lineWidth ?? 3) + 1,
+              },
+              itemStyle: {
+                color: lineColor,
+                borderColor: themeColors.background,
+                borderWidth: 2,
+              },
+            },
+            yAxisIndex: s.yAxisIndex ?? 0,
+            z: s.z,
+          };
+        }),
       ],
     };
   }, [


### PR DESCRIPTION
## Summary

Fixed an issue on step charts where hovering points with flat horizontal segments (same Y value across consecutive X values) would fail to show tooltips for middle points.

- Add `triggerOn: 'mousemove'` to enable fine-grained tooltip tracking
- Add `snap: true` to axisPointers to snap to data points  
- Auto-enable hover symbols (8px circle with white border) for all series
- Improves interaction on MultiLine, Line, and ScatterAndLine charts
