### PR TITLE
feat: add ForkLabel component for beacon chain forks

### DIFF
--- a/src/components/Ethereum/ForkLabel/ForkLabel.stories.tsx
+++ b/src/components/Ethereum/ForkLabel/ForkLabel.stories.tsx
@@ -1,0 +1,127 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { ForkLabel } from './ForkLabel';
+
+const meta = {
+  title: 'Components/Ethereum/ForkLabel',
+  component: ForkLabel,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <div className="min-w-[600px] rounded-sm bg-surface p-6">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ForkLabel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Phase0: Story = {
+  args: {
+    fork: 'phase0',
+  },
+};
+
+export const Altair: Story = {
+  args: {
+    fork: 'altair',
+  },
+};
+
+export const Bellatrix: Story = {
+  args: {
+    fork: 'bellatrix',
+  },
+};
+
+export const Capella: Story = {
+  args: {
+    fork: 'capella',
+  },
+};
+
+export const Deneb: Story = {
+  args: {
+    fork: 'deneb',
+  },
+};
+
+export const Electra: Story = {
+  args: {
+    fork: 'electra',
+  },
+};
+
+export const Fulu: Story = {
+  args: {
+    fork: 'fulu',
+  },
+};
+
+export const SmallSize: Story = {
+  args: {
+    fork: 'deneb',
+    size: 'sm',
+  },
+};
+
+export const MediumSize: Story = {
+  args: {
+    fork: 'deneb',
+    size: 'md',
+  },
+};
+
+export const LargeSize: Story = {
+  args: {
+    fork: 'deneb',
+    size: 'lg',
+  },
+};
+
+export const WithoutIcon: Story = {
+  args: {
+    fork: 'bellatrix',
+    showIcon: false,
+  },
+};
+
+export const AllForks: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <ForkLabel fork="phase0" />
+        <ForkLabel fork="altair" />
+        <ForkLabel fork="bellatrix" />
+        <ForkLabel fork="capella" />
+        <ForkLabel fork="deneb" />
+        <ForkLabel fork="electra" />
+        <ForkLabel fork="fulu" />
+      </div>
+    </div>
+  ),
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <span className="w-20 text-sm text-muted">Small:</span>
+        <ForkLabel fork="deneb" size="sm" />
+      </div>
+      <div className="flex items-center gap-3">
+        <span className="w-20 text-sm text-muted">Medium:</span>
+        <ForkLabel fork="deneb" size="md" />
+      </div>
+      <div className="flex items-center gap-3">
+        <span className="w-20 text-sm text-muted">Large:</span>
+        <ForkLabel fork="deneb" size="lg" />
+      </div>
+    </div>
+  ),
+};

--- a/src/components/Ethereum/ForkLabel/ForkLabel.tsx
+++ b/src/components/Ethereum/ForkLabel/ForkLabel.tsx
@@ -1,0 +1,51 @@
+import clsx from 'clsx';
+
+import { FORK_METADATA } from '@/utils/beacon';
+
+import type { ForkLabelProps } from './ForkLabel.types';
+
+/**
+ * Displays a beacon chain fork label with emoji icon and name
+ *
+ * @example
+ * // Default size with icon
+ * <ForkLabel fork="deneb" />
+ *
+ * @example
+ * // Small size without icon
+ * <ForkLabel fork="altair" size="sm" showIcon={false} />
+ *
+ * @example
+ * // Large size with custom styling
+ * <ForkLabel fork="bellatrix" size="lg" className="shadow-lg" />
+ */
+export function ForkLabel({ fork, className, size = 'md', showIcon = true }: ForkLabelProps): React.JSX.Element {
+  const metadata = FORK_METADATA[fork];
+
+  const sizeClasses = {
+    sm: 'px-2 py-0.5 text-xs gap-1',
+    md: 'px-3 py-1 text-sm gap-1.5',
+    lg: 'px-4 py-1.5 text-base gap-2',
+  };
+
+  const iconSizeClasses = {
+    sm: 'text-sm',
+    md: 'text-base',
+    lg: 'text-lg',
+  };
+
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center rounded-md font-semibold tracking-wide uppercase',
+        metadata.color,
+        sizeClasses[size],
+        className
+      )}
+      title={metadata.description}
+    >
+      {showIcon && <span className={iconSizeClasses[size]}>{metadata.emoji}</span>}
+      <span>{metadata.name}</span>
+    </span>
+  );
+}

--- a/src/components/Ethereum/ForkLabel/ForkLabel.types.ts
+++ b/src/components/Ethereum/ForkLabel/ForkLabel.types.ts
@@ -1,0 +1,25 @@
+import type { ForkVersion } from '@/utils/beacon';
+
+export interface ForkLabelProps {
+  /**
+   * The fork version to display
+   */
+  fork: ForkVersion;
+
+  /**
+   * Optional className for styling
+   */
+  className?: string;
+
+  /**
+   * Display size variant
+   * @default 'md'
+   */
+  size?: 'sm' | 'md' | 'lg';
+
+  /**
+   * Whether to show the emoji icon
+   * @default true
+   */
+  showIcon?: boolean;
+}

--- a/src/components/Ethereum/ForkLabel/index.ts
+++ b/src/components/Ethereum/ForkLabel/index.ts
@@ -1,0 +1,2 @@
+export { ForkLabel } from './ForkLabel';
+export type { ForkLabelProps } from './ForkLabel.types';

--- a/src/utils/beacon.ts
+++ b/src/utils/beacon.ts
@@ -152,3 +152,79 @@ export function isEpochAtOrAfter(currentEpoch: number, forkEpoch?: number): bool
   }
   return currentEpoch >= forkEpoch;
 }
+
+/**
+ * Beacon chain fork version identifiers
+ */
+export type ForkVersion = 'phase0' | 'altair' | 'bellatrix' | 'capella' | 'deneb' | 'electra' | 'fulu';
+
+/**
+ * Metadata for a beacon chain fork
+ */
+export interface ForkMetadata {
+  /** Fork version identifier */
+  version: ForkVersion;
+  /** Display name */
+  name: string;
+  /** Emoji icon representing the fork */
+  emoji: string;
+  /** Tailwind color classes for the fork label */
+  color: string;
+  /** Description of what the fork represents */
+  description: string;
+}
+
+/**
+ * Fork metadata constants for all beacon chain forks
+ */
+export const FORK_METADATA: Record<ForkVersion, ForkMetadata> = {
+  phase0: {
+    version: 'phase0',
+    name: 'Phase 0',
+    emoji: '🚀',
+    color: 'bg-gray-100 text-gray-700 dark:bg-gray-400/10 dark:text-gray-400',
+    description: 'Genesis - Beacon chain launch',
+  },
+  altair: {
+    version: 'altair',
+    name: 'Altair',
+    emoji: '🦅',
+    color: 'bg-sky-100 text-sky-700 dark:bg-sky-400/10 dark:text-sky-400',
+    description: 'First beacon chain upgrade - Light client support',
+  },
+  bellatrix: {
+    version: 'bellatrix',
+    name: 'Bellatrix',
+    emoji: '🐼',
+    color: 'bg-slate-100 text-slate-700 dark:bg-slate-400/10 dark:text-slate-400',
+    description: 'The Merge - Transition to proof-of-stake',
+  },
+  capella: {
+    version: 'capella',
+    name: 'Capella',
+    emoji: '🐋',
+    color: 'bg-blue-100 text-blue-700 dark:bg-blue-400/10 dark:text-blue-400',
+    description: 'Shanghai/Capella - Validator withdrawals enabled',
+  },
+  deneb: {
+    version: 'deneb',
+    name: 'Deneb',
+    emoji: '🐡',
+    color: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-400/10 dark:text-indigo-400',
+    description: 'Cancun/Deneb - Proto-danksharding (EIP-4844)',
+  },
+  electra: {
+    version: 'electra',
+    name: 'Electra',
+    emoji: '🦒',
+    color: 'bg-violet-100 text-violet-700 dark:bg-violet-400/10 dark:text-violet-400',
+    description: 'Electra upgrade - MaxEB and other improvements',
+  },
+  fulu: {
+    version: 'fulu',
+    name: 'Fulu',
+    emoji: '🦓',
+    color: 'bg-pink-100 text-pink-700 dark:bg-pink-400/10 dark:text-pink-400',
+    description: 'Future upgrade - PeerDAS and more',
+  },
+} as const;


### PR DESCRIPTION
## Summary

This PR adds a new **ForkLabel** Ethereum core component to display beacon chain fork versions with themed colors and animal emojis.

<img width="837" height="76" alt="Screenshot 2025-11-04 at 12 08 56 pm" src="https://github.com/user-attachments/assets/6535886d-2e1d-48fe-9ab4-203f0b0eb7c8" />
