### PR TITLE
feat: add network icon to mobile header

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -104,7 +104,11 @@ function MobileHeader({
         </Link>
       </div>
       <div className="flex items-center gap-3">
-        {currentNetwork && <NetworkIcon networkName={currentNetwork.name} className="size-6" />}
+        {currentNetwork && (
+          <span title={currentNetwork.display_name} className="cursor-default">
+            <NetworkIcon networkName={currentNetwork.name} className="size-6" />
+          </span>
+        )}
         <ThemeToggle />
       </div>
     </div>


### PR DESCRIPTION
## Summary

Add the selected network's icon to the mobile top bar next to the theme toggle for improved network visibility on mobile devices.

<img width="391" height="843" alt="Screenshot 2025-11-04 at 4 37 54 pm" src="https://github.com/user-attachments/assets/d334135d-414b-4ca8-8349-e0098524da5d" />
