### PR TITLE
feat: add arrow navigation to slot and epoch detail pages

### DIFF
--- a/src/pages/ethereum/epochs/DetailPage.tsx
+++ b/src/pages/ethereum/epochs/DetailPage.tsx
@@ -178,7 +178,7 @@ export function DetailPage(): React.JSX.Element {
         >
           Previous
         </Button>
-        <div className="text-sm text-muted">Use ← → arrow keys to navigate</div>
+        <div className="flex-1" />
         <Button
           variant="secondary"
           size="sm"

--- a/src/pages/ethereum/slots/DetailPage.tsx
+++ b/src/pages/ethereum/slots/DetailPage.tsx
@@ -278,7 +278,7 @@ export function DetailPage(): JSX.Element {
         >
           Previous
         </Button>
-        <div className="text-sm text-muted">Use ← → arrow keys to navigate</div>
+        <div className="flex-1" />
         <Button
           variant="secondary"
           size="sm"


### PR DESCRIPTION
## Summary
Add keyboard and button navigation to the slot and epoch detail pages, allowing users to browse sequentially through slots and epochs.

<img width="1400" height="933" alt="image" src="https://github.com/user-attachments/assets/8b9e2022-ee9d-48c5-9180-930df759babc" />
