### PR TITLE
fix(fork-readiness): add safe navigation for min_client_versions

### DIFF
--- a/frontend/src/pages/xatu-data/fork-readiness/index.tsx
+++ b/frontend/src/pages/xatu-data/fork-readiness/index.tsx
@@ -150,10 +150,11 @@ function ForkReadiness() {
     return (
       availableForks
         .map(fork => {
-          const knownClientNames = Object.keys(fork.data.min_client_versions || {});
+          const minClientVersions = fork.data?.min_client_versions || {};
+          const knownClientNames = Object.keys(minClientVersions);
 
           // Process known clients
-          const knownClientReadiness = Object.entries(fork.data.min_client_versions || {})
+          const knownClientReadiness = Object.entries(minClientVersions)
             .map(([clientName, minVersion]) => {
               const clientNodes = nodes.filter(n => n.consensus_client === clientName);
               const readyNodes = clientNodes.filter(n => {


### PR DESCRIPTION
## Summary

Fixes a `TypeError: Cannot convert undefined or null to object` error that occurs when the fork readiness component tries to access `min_client_versions` from an undefined `fork.data` object.

## Changes

- Added optional chaining (`?.`) to safely access `fork.data.min_client_versions`
- Extracted `min_client_versions` to a variable with a fallback to empty object
- This prevents errors when fork configuration is not fully initialized

## Test Plan

- [x] Component should no longer throw TypeError when rendering with undefined fork data
- [x] Fallback to empty object ensures no entries to process when configuration is missing
- [x] All existing functionality remains unchanged for valid configurations