### PR TITLE
feat: URL-based tab state with hash anchor scrolling

### DIFF
--- a/src/hooks/useTabState/index.ts
+++ b/src/hooks/useTabState/index.ts
@@ -1,0 +1,2 @@
+export { useTabState } from './useTabState';
+export type { TabConfig, UseTabStateReturn } from './useTabState.types';

--- a/src/hooks/useTabState/useTabState.ts
+++ b/src/hooks/useTabState/useTabState.ts
@@ -1,0 +1,194 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useSearch } from '@tanstack/react-router';
+import type { TabConfig, UseTabStateReturn } from './useTabState.types';
+
+/**
+ * Hook for URL-based tab state management with automatic anchor scrolling
+ *
+ * Manages tab state using TanStack Router search params and handles:
+ * - Setting initial tab from URL search params or hash (for backward compatibility)
+ * - Updating URL when tabs change
+ * - Deep linking to anchors within tabs (scrolls after content loads)
+ * - Browser back/forward navigation
+ * - Automatic migration from hash-based to search-param-based URLs
+ *
+ * **Developer-friendly API**: Just define your tabs and get back state management.
+ * All URL complexity is handled internally.
+ *
+ * @example
+ * ```tsx
+ * // 1. In your route file, add search param validation:
+ * validateSearch: zodValidator(
+ *   z.object({
+ *     tab: z.enum(['overview', 'blocks', 'mev']).default('overview')
+ *   })
+ * )
+ *
+ * // 2. In your page component, use the hook:
+ * const { selectedIndex, onChange } = useTabState([
+ *   { id: 'overview' },
+ *   { id: 'blocks', anchors: ['blob-count-chart', 'gas-chart'] },
+ *   { id: 'mev', anchors: ['mev-adoption-chart'] },
+ * ]);
+ *
+ * // 3. Wire it up to HeadlessUI:
+ * <TabGroup selectedIndex={selectedIndex} onChange={onChange}>
+ *   <TabList>
+ *     <Tab>Overview</Tab>
+ *     <Tab>Blocks</Tab>
+ *     <Tab>MEV</Tab>
+ *   </TabList>
+ *   <TabPanels>...</TabPanels>
+ * </TabGroup>
+ *
+ * // That's it! The hook handles:
+ * // - URL updates: /slots/123?tab=blocks
+ * // - Anchor scrolling: /slots/123?tab=blocks#blob-count-chart
+ * // - Backward compat: /slots/123#blocks → redirects to ?tab=blocks
+ * ```
+ */
+export function useTabState(tabs: TabConfig[]): UseTabStateReturn {
+  const navigate = useNavigate();
+  const searchParams = useSearch({ strict: false }) as { tab?: string };
+  const [shouldScrollToAnchor, setShouldScrollToAnchor] = useState(false);
+
+  /**
+   * Determine initial tab index from URL
+   * Priority: search param > hash (for backward compat) > default (0)
+   */
+  const getInitialTab = (): number => {
+    // First, check search params (new format)
+    if (searchParams.tab) {
+      const index = tabs.findIndex(tab => tab.id === searchParams.tab);
+      if (index >= 0) return index;
+    }
+
+    // Fallback: check hash for backward compatibility
+    const hash = window.location.hash.replace('#', '');
+    if (hash) {
+      // Check if it's a direct tab hash
+      const directIndex = tabs.findIndex(tab => tab.id === hash);
+      if (directIndex >= 0) {
+        // Migrate to new format
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-restricted-syntax
+        (navigate as any)({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-restricted-syntax
+          search: (prev: any) => ({ ...prev, tab: hash }),
+          replace: true,
+          hash: undefined,
+        });
+        return directIndex;
+      }
+
+      // Check if it's an anchor within a tab
+      const anchorIndex = tabs.findIndex(tab => tab.anchors?.includes(hash));
+      if (anchorIndex >= 0) {
+        // Migrate to new format, preserving the anchor
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-restricted-syntax
+        (navigate as any)({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-restricted-syntax
+          search: (prev: any) => ({ ...prev, tab: tabs[anchorIndex].id }),
+          replace: true,
+          hash,
+        });
+        setShouldScrollToAnchor(true);
+        return anchorIndex;
+      }
+    }
+
+    return 0;
+  };
+
+  const [selectedIndex, setSelectedIndex] = useState(getInitialTab);
+
+  /**
+   * Scroll to anchor after content has loaded
+   * Uses retry logic to handle async data loading
+   */
+  useEffect(() => {
+    if (!shouldScrollToAnchor) return;
+
+    const hash = window.location.hash.replace('#', '');
+    if (!hash) {
+      setShouldScrollToAnchor(false);
+      return;
+    }
+
+    let attempts = 0;
+    const maxAttempts = 50; // 5 seconds max (50 * 100ms)
+
+    const tryScroll = (): void => {
+      const element = document.getElementById(hash);
+      if (element) {
+        // Element found - scroll to it
+        element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        setShouldScrollToAnchor(false);
+      } else if (attempts < maxAttempts) {
+        // Element not found yet - retry
+        attempts++;
+        setTimeout(tryScroll, 100);
+      } else {
+        // Give up after max attempts
+        setShouldScrollToAnchor(false);
+      }
+    };
+
+    // Start scrolling attempts after a brief delay to let the tab panel render
+    const timeoutId = setTimeout(tryScroll, 100);
+
+    return () => clearTimeout(timeoutId);
+  }, [shouldScrollToAnchor]);
+
+  /**
+   * Sync with URL changes (browser back/forward)
+   */
+  useEffect(() => {
+    if (searchParams.tab) {
+      const index = tabs.findIndex(tab => tab.id === searchParams.tab);
+      if (index >= 0 && index !== selectedIndex) {
+        setSelectedIndex(index);
+
+        // Check if there's also a hash to scroll to
+        if (window.location.hash) {
+          setShouldScrollToAnchor(true);
+        }
+      }
+    }
+  }, [searchParams.tab, tabs, selectedIndex]);
+
+  /**
+   * Handle tab changes - update URL and manage scrolling
+   */
+  const onChange = (index: number): void => {
+    const newTab = tabs[index];
+    setSelectedIndex(index);
+
+    const currentHash = window.location.hash.replace('#', '');
+
+    // Check if current hash is an anchor within the NEW tab
+    const hashBelongsToNewTab = newTab.anchors?.includes(currentHash);
+
+    if (hashBelongsToNewTab) {
+      // Keep the anchor and scroll to it
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-restricted-syntax
+      (navigate as any)({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-restricted-syntax
+        search: (prev: any) => ({ ...prev, tab: newTab.id }),
+        replace: true,
+        hash: currentHash,
+      });
+      setShouldScrollToAnchor(true);
+    } else {
+      // Clear the hash when switching tabs
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-restricted-syntax
+      (navigate as any)({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-restricted-syntax
+        search: (prev: any) => ({ ...prev, tab: newTab.id }),
+        replace: true,
+        hash: undefined,
+      });
+    }
+  };
+
+  return { selectedIndex, onChange };
+}

--- a/src/hooks/useTabState/useTabState.types.ts
+++ b/src/hooks/useTabState/useTabState.types.ts
@@ -1,0 +1,19 @@
+/**
+ * Configuration for a tab with URL-based routing
+ */
+export interface TabConfig {
+  /** Unique identifier for this tab (used in URL search params) */
+  id: string;
+  /** Optional array of anchor IDs that belong to this tab for deep linking */
+  anchors?: string[];
+}
+
+/**
+ * Return type for useTabState hook
+ */
+export interface UseTabStateReturn {
+  /** Current selected tab index */
+  selectedIndex: number;
+  /** Handler for tab change - automatically updates URL */
+  onChange: (index: number) => void;
+}

--- a/src/pages/ethereum/entities/DetailPage.tsx
+++ b/src/pages/ethereum/entities/DetailPage.tsx
@@ -9,7 +9,7 @@ import { LoadingContainer } from '@/components/Layout/LoadingContainer';
 import { Tab } from '@/components/Navigation/Tab';
 import { ScrollableTabs } from '@/components/Navigation/ScrollableTabs';
 import { useNetworkChangeRedirect } from '@/hooks/useNetworkChangeRedirect';
-import { useHashTabs } from '@/hooks/useHashTabs';
+import { useTabState } from '@/hooks/useTabState';
 import { Route } from '@/routes/ethereum/entities/$entity';
 
 import { AttestationRateChart, AttestationVolumeChart, EntityBasicInfoCard, RecentActivityTable } from './components';
@@ -47,11 +47,11 @@ export function DetailPage(): React.JSX.Element {
   // Fetch data for this entity
   const { data, isLoading, error } = useEntityDetailData(entityName ?? '');
 
-  // Hash-based tab routing
-  const { selectedIndex, onChange } = useHashTabs([
-    { hash: 'recent', anchors: ['recent-activity'] },
-    { hash: 'attestations', anchors: ['attestation-rate-chart', 'attestation-volume-chart'] },
-    { hash: 'blocks', anchors: ['block-proposals'] },
+  // Tab state management with URL search params
+  const { selectedIndex, onChange } = useTabState([
+    { id: 'recent', anchors: ['recent-activity'] },
+    { id: 'attestations', anchors: ['attestation-rate-chart', 'attestation-volume-chart'] },
+    { id: 'blocks', anchors: ['block-proposals'] },
   ]);
 
   // Handle invalid entity
@@ -112,9 +112,9 @@ export function DetailPage(): React.JSX.Element {
       <div className="mt-6">
         <TabGroup selectedIndex={selectedIndex} onChange={onChange}>
           <ScrollableTabs>
-            <Tab hash="recent">Recent</Tab>
-            <Tab hash="attestations">Attestations</Tab>
-            <Tab hash="blocks">Blocks</Tab>
+            <Tab>Recent</Tab>
+            <Tab>Attestations</Tab>
+            <Tab>Blocks</Tab>
           </ScrollableTabs>
 
           <TabPanels className="mt-6">

--- a/src/pages/ethereum/epochs/DetailPage.tsx
+++ b/src/pages/ethereum/epochs/DetailPage.tsx
@@ -24,7 +24,7 @@ import { ScrollableTabs } from '@/components/Navigation/ScrollableTabs';
 import { formatEpoch } from '@/utils';
 import { weiToEth } from '@/utils/ethereum';
 import { useNetworkChangeRedirect } from '@/hooks/useNetworkChangeRedirect';
-import { useHashTabs } from '@/hooks/useHashTabs';
+import { useTabState } from '@/hooks/useTabState';
 import { Route } from '@/routes/ethereum/epochs/$epoch';
 
 import { EpochHeader, EpochSlotsTable } from './components';
@@ -82,11 +82,11 @@ export function DetailPage(): React.JSX.Element {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [epoch, navigate]);
 
-  // Hash-based tab routing
-  const { selectedIndex, onChange } = useHashTabs([
-    { hash: 'slots' },
+  // Tab state management with URL search params
+  const { selectedIndex, onChange } = useTabState([
+    { id: 'slots' },
     {
-      hash: 'blocks',
+      id: 'blocks',
       anchors: [
         'blob-count-chart',
         'gas-chart',
@@ -96,9 +96,9 @@ export function DetailPage(): React.JSX.Element {
         'block-arrival-times-chart',
       ],
     },
-    { hash: 'validators', anchors: ['missed-attestations-chart'] },
+    { id: 'validators', anchors: ['missed-attestations-chart'] },
     {
-      hash: 'mev',
+      id: 'mev',
       anchors: [
         'mev-adoption-chart',
         'block-value-chart',
@@ -203,10 +203,10 @@ export function DetailPage(): React.JSX.Element {
       <div className="mt-8">
         <TabGroup selectedIndex={selectedIndex} onChange={onChange}>
           <ScrollableTabs>
-            <Tab hash="slots">Slots</Tab>
-            <Tab hash="blocks">Blocks</Tab>
-            <Tab hash="validators">Validators</Tab>
-            <Tab hash="mev">MEV</Tab>
+            <Tab>Slots</Tab>
+            <Tab>Blocks</Tab>
+            <Tab>Validators</Tab>
+            <Tab>MEV</Tab>
           </ScrollableTabs>
 
           <TabPanels className="mt-6">

--- a/src/pages/ethereum/slots/DetailPage.tsx
+++ b/src/pages/ethereum/slots/DetailPage.tsx
@@ -13,7 +13,7 @@ import { Button } from '@/components/Elements/Button';
 import { SLOTS_PER_EPOCH, slotToTimestamp } from '@/utils/beacon';
 import { formatEpoch } from '@/utils';
 import { useNetworkChangeRedirect } from '@/hooks/useNetworkChangeRedirect';
-import { useHashTabs } from '@/hooks/useHashTabs';
+import { useTabState } from '@/hooks/useTabState';
 import { useNetwork } from '@/hooks/useNetwork';
 import { Route } from '@/routes/ethereum/slots/$slot';
 import { useSlotDetailData } from './hooks/useSlotDetailData';
@@ -91,14 +91,14 @@ export function DetailPage(): JSX.Element {
     !!currentNetwork && slotTimestamp > 0
   );
 
-  // Hash-based tab routing
-  const { selectedIndex, onChange } = useHashTabs([
-    { hash: 'overview' },
-    { hash: 'block' },
-    { hash: 'attestations', anchors: ['missed-attestations'] },
-    { hash: 'propagation' },
-    { hash: 'execution' },
-    { hash: 'mev' },
+  // Tab state management with URL search params
+  const { selectedIndex, onChange } = useTabState([
+    { id: 'overview' },
+    { id: 'block' },
+    { id: 'attestations', anchors: ['missed-attestations'] },
+    { id: 'propagation' },
+    { id: 'execution' },
+    { id: 'mev' },
   ]);
 
   // Validate slot number
@@ -301,12 +301,12 @@ export function DetailPage(): JSX.Element {
       <div className="mt-8">
         <TabGroup selectedIndex={selectedIndex} onChange={onChange}>
           <ScrollableTabs>
-            <Tab hash="overview">Overview</Tab>
-            <Tab hash="block">Block</Tab>
-            <Tab hash="attestations">Attestations</Tab>
-            <Tab hash="propagation">Propagation</Tab>
-            <Tab hash="execution">Execution</Tab>
-            {hasMevData && <Tab hash="mev">MEV</Tab>}
+            <Tab>Overview</Tab>
+            <Tab>Block</Tab>
+            <Tab>Attestations</Tab>
+            <Tab>Propagation</Tab>
+            <Tab>Execution</Tab>
+            {hasMevData && <Tab>MEV</Tab>}
           </ScrollableTabs>
 
           <TabPanels className="mt-6">

--- a/src/routes/ethereum/entities/$entity.tsx
+++ b/src/routes/ethereum/entities/$entity.tsx
@@ -1,9 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router';
-
+import { z } from 'zod';
 import { DetailPage } from '@/pages/ethereum/entities';
+
+const entitySearchSchema = z.object({
+  tab: z.enum(['recent', 'attestations', 'blocks']).default('recent'),
+});
 
 export const Route = createFileRoute('/ethereum/entities/$entity')({
   component: DetailPage,
+  validateSearch: entitySearchSchema,
   beforeLoad: ({ params }) => ({
     getBreadcrumb: () => ({ label: params.entity }),
     redirectOnNetworkChange: '/ethereum/entities',

--- a/src/routes/ethereum/epochs/$epoch.tsx
+++ b/src/routes/ethereum/epochs/$epoch.tsx
@@ -1,9 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router';
-
+import { z } from 'zod';
 import { DetailPage } from '@/pages/ethereum/epochs';
+
+const epochSearchSchema = z.object({
+  tab: z.enum(['slots', 'blocks', 'validators', 'mev']).default('slots'),
+});
 
 export const Route = createFileRoute('/ethereum/epochs/$epoch')({
   component: DetailPage,
+  validateSearch: epochSearchSchema,
   beforeLoad: ({ params }) => ({
     getBreadcrumb: () => ({ label: params.epoch }),
     redirectOnNetworkChange: '/ethereum/epochs',

--- a/src/routes/ethereum/slots/$slot.tsx
+++ b/src/routes/ethereum/slots/$slot.tsx
@@ -1,8 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
 import { DetailPage } from '@/pages/ethereum/slots';
+
+const slotSearchSchema = z.object({
+  tab: z.enum(['overview', 'block', 'attestations', 'propagation', 'execution', 'mev']).default('overview'),
+});
 
 export const Route = createFileRoute('/ethereum/slots/$slot')({
   component: DetailPage,
+  validateSearch: slotSearchSchema,
   beforeLoad: ({ params }) => ({
     getBreadcrumb: () => ({ label: params.slot }),
     redirectOnNetworkChange: '/ethereum/slots',


### PR DESCRIPTION
## Summary

Implement URL-based tab state management replacing hash-based routing. Tabs now use TanStack Router search params (`?tab=propagation`) while hash fragments (`#blob-count-chart`) handle deep linking to content anchors.
