### PR TITLE
fix: prevent scroll to top when switching tabs

### DIFF
--- a/src/hooks/useTabState/useTabState.ts
+++ b/src/hooks/useTabState/useTabState.ts
@@ -168,6 +168,9 @@ export function useTabState(tabs: TabConfig[]): UseTabStateReturn {
     // Check if current hash is an anchor within the NEW tab
     const hashBelongsToNewTab = newTab.anchors?.includes(currentHash);
 
+    // Store current scroll position before navigation
+    const scrollY = window.scrollY;
+
     if (hashBelongsToNewTab) {
       // Keep the anchor and scroll to it
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-restricted-syntax
@@ -186,6 +189,12 @@ export function useTabState(tabs: TabConfig[]): UseTabStateReturn {
         search: (prev: any) => ({ ...prev, tab: newTab.id }),
         replace: true,
         hash: undefined,
+      });
+
+      // Restore scroll position after navigation to prevent scroll to top
+      // This prevents the jarring scroll behavior on both desktop and mobile
+      requestAnimationFrame(() => {
+        window.scrollTo(0, scrollY);
       });
     }
   };


### PR DESCRIPTION
## Summary

Preserve scroll position when changing tabs in detail pages (slots/epochs). The page would previously jump to the top whenever a user clicked a tab, creating a jarring experience on both desktop and mobile.

## Solution

Capture the scroll position before navigation and restore it after using `requestAnimationFrame`. This ensures the scroll restoration happens at the right time in the browser's rendering cycle.

## Testing

Test on both desktop and mobile by clicking tabs in:
- Slot detail pages (`/ethereum/slots/$slot`)
- Epoch detail pages (`/ethereum/epochs/$epoch`)

The scroll position should remain unchanged when switching between tabs.