### PR TITLE
fix: expand Apple Watch detection to cover all models

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -120,10 +120,10 @@ function RootComponent(): JSX.Element {
   const [isAppleWatch, setIsAppleWatch] = useState(false);
   const router = useRouter();
 
-  // Detect Apple Watch screen size (typically 136-205px wide)
+  // Detect Apple Watch screen size (312-416px wide across all models)
   useEffect(() => {
     const checkScreenSize = (): void => {
-      setIsAppleWatch(window.innerWidth <= 205);
+      setIsAppleWatch(window.innerWidth <= 416);
     };
 
     checkScreenSize();


### PR DESCRIPTION
Expands Apple Watch screen detection threshold from 205px to 416px to ensure the clown face emoji displays correctly across all Apple Watch models (312-416px width range, from Series 0 to Series 10).