### PR TITLE
fix: remount live slot page on network change

### DIFF
--- a/src/routes/ethereum/live.tsx
+++ b/src/routes/ethereum/live.tsx
@@ -2,10 +2,15 @@ import type { JSX } from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 import { IndexPage } from '@/pages/ethereum/live';
 import { SlotPlayerProvider } from '@/providers/SlotPlayerProvider';
+import { useNetwork } from '@/hooks/useNetwork';
 
 function LivePage(): JSX.Element {
+  const { currentNetwork } = useNetwork();
+
+  // Force remount when network changes to get fresh data for the new network
   return (
     <SlotPlayerProvider
+      key={currentNetwork?.name}
       tables={['fct_block_head', 'fct_block_first_seen_by_node', 'fct_attestation_first_seen_chunked_50ms']}
       initialPlaying={true}
     >


### PR DESCRIPTION
## Summary

Force the live slot page to remount when the network changes. This ensures fresh slot data is fetched for the newly selected network instead of attempting to update state in place.

## Changes

- Added network-based key to SlotPlayerProvider to trigger component remount
- Component now fetches fresh slot bounds for each network
- Improves UX when switching between networks

## Test Plan

- [x] Switch between different networks on the live page
- [x] Verify new slot data appears for each network
- [x] Build and lint pass