### PR TITLE
fix: remove jarring cyan-to-pink gradient in star theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -265,10 +265,10 @@
   }
 
   html.star {
-    /* Star mode - aurora borealis with pink and purple */
+    /* Star mode - aurora borealis with cyan and purple (no pink gradient) */
     --primary-value: var(--color-aurora-cyan-400);
     --secondary-value: var(--color-aurora-purple-600);
-    --accent-value: var(--color-aurora-pink-500);
+    --accent-value: var(--color-aurora-cyan-300);
     --background-value: var(--color-aurora-blue-950);
     --surface-value: #0a1428;
     --foreground-value: var(--color-aurora-cyan-50);


### PR DESCRIPTION
Replace the clashing pink accent with cyan to maintain a cohesive aurora borealis color palette throughout the star theme.