### PR TITLE
Revert Map2D useMemo dependencies causing flickering

### DIFF
--- a/src/components/Charts/Map2D/Map2D.tsx
+++ b/src/components/Charts/Map2D/Map2D.tsx
@@ -287,7 +287,7 @@ function Map2DChartComponent({
       series,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mapLoaded, routes, showEffect, lineColor, title]); // Recalculate when key props change
+  }, [mapLoaded]); // Only recalculate when map loads - after that we update via setOption
 
   // Don't render until map is loaded
   if (!mapLoaded) {


### PR DESCRIPTION
Fix flickering in the live slot view by reverting the addition of excessive dependencies to the Map2D useMemo hook. These dependencies caused the chart options to recalculate on every prop change, triggering unnecessary re-renders.

The original behavior where chart options are only recalculated when the map loads is more efficient and allows updates to be handled via setOption calls.