### PR TITLE
Fix missed slot status and add auto-refetch for live epochs

### DIFF
--- a/src/pages/ethereum/epochs/DetailPage.tsx
+++ b/src/pages/ethereum/epochs/DetailPage.tsx
@@ -23,6 +23,7 @@ import { Tab } from '@/components/Navigation/Tab';
 import { ScrollableTabs } from '@/components/Navigation/ScrollableTabs';
 import { formatEpoch } from '@/utils';
 import { weiToEth } from '@/utils/ethereum';
+import { useBeaconClock } from '@/hooks/useBeaconClock';
 import { useNetworkChangeRedirect } from '@/hooks/useNetworkChangeRedirect';
 import { useTabState } from '@/hooks/useTabState';
 import { Route } from '@/routes/ethereum/epochs/$epoch';
@@ -52,8 +53,12 @@ export function DetailPage(): React.JSX.Element {
   const parsed = parseInt(params.epoch, 10);
   const epoch = isNaN(parsed) || parsed < 0 ? null : parsed;
 
+  // Determine if this is the current epoch (for auto-refetch)
+  const { epoch: currentEpoch } = useBeaconClock();
+  const isLiveEpoch = epoch !== null && epoch === currentEpoch;
+
   // Fetch data for this epoch
-  const { data, isLoading, error } = useEpochDetailData(epoch ?? 0);
+  const { data, isLoading, error } = useEpochDetailData(epoch ?? 0, isLiveEpoch);
 
   // Keyboard navigation
   useEffect(() => {

--- a/src/utils/beacon.ts
+++ b/src/utils/beacon.ts
@@ -78,6 +78,22 @@ export function slotToTimestamp(slot: number, genesisTime: number): number {
 }
 
 /**
+ * Convert Unix timestamp to slot number
+ *
+ * @param timestamp - Unix timestamp in seconds
+ * @param genesisTime - Genesis time in Unix seconds
+ * @returns Beacon chain slot number
+ *
+ * @example
+ * ```tsx
+ * timestampToSlot(1606825223, 1606824023) // Returns 100
+ * ```
+ */
+export function timestampToSlot(timestamp: number, genesisTime: number): number {
+  return Math.floor((timestamp - genesisTime) / SECONDS_PER_SLOT);
+}
+
+/**
  * Convert slot number to epoch number
  *
  * @param slot - Slot number


### PR DESCRIPTION
## Summary

- Only display "Missed" slot status when the datasource has processed beyond that slot
- Show "Pending" status for slots still being processed, preventing false positives
- Add `timestampToSlot` utility to convert bounds timestamps to slot numbers
- Enable automatic data refresh every 12s for current (live) epoch
- Disable refresh for historical epochs to improve performance

## Test plan

- View current epoch - should see data refresh every 12s
- View historical epochs - should not refresh
- Verify "Missed" badges only appear for slots beyond datasource bounds
- Verify "Pending" shows while datasource is processing