### PR TITLE
Improve PeerDAS heatmap visualization

### DIFF
--- a/src/components/Charts/Heatmap/Heatmap.tsx
+++ b/src/components/Charts/Heatmap/Heatmap.tsx
@@ -39,6 +39,7 @@ export function HeatmapChart({
   animationDuration = 300,
   formatValue,
   showCellBorders = false,
+  cellBorderConfig,
   xAxisTitle,
   yAxisTitle,
   visualMapType = 'continuous',
@@ -152,7 +153,7 @@ export function HeatmapChart({
             type: 'continuous',
             min: min ?? Math.min(...data.map(d => d[2])),
             max: max ?? Math.max(...data.map(d => d[2])),
-            calculable: true,
+            calculable: false,
             orient: 'vertical',
             right: 10,
             top: 'center',
@@ -164,6 +165,9 @@ export function HeatmapChart({
               color: themeColors.foreground,
               fontSize: 12,
             },
+            text: ['4s', '0s'],
+            itemWidth: 15,
+            itemHeight: 100,
           },
     series: [
       {
@@ -180,14 +184,21 @@ export function HeatmapChart({
         },
         itemStyle: {
           ...(showCellBorders && {
-            borderColor: themeColors.border,
-            borderWidth: 1,
+            borderColor: themeColors.background,
+            borderWidth: 2,
+          }),
+          ...(cellBorderConfig && {
+            borderColor: cellBorderConfig.borderColor ?? themeColors.background,
+            borderWidth: cellBorderConfig.borderWidth ?? 2,
           }),
         },
-        // ECharts hover effects: 'self' highlights single cell, 'series' highlights column
+        // ECharts hover effects: subtle highlight on hover
         emphasis: {
           disabled: emphasisDisabled,
-          focus: emphasisDisabled ? 'none' : ('series' as const),
+          itemStyle: {
+            borderColor: themeColors.foreground,
+            borderWidth: 2,
+          },
         },
       },
     ],

--- a/src/components/Charts/Heatmap/Heatmap.types.ts
+++ b/src/components/Charts/Heatmap/Heatmap.types.ts
@@ -58,6 +58,14 @@ export interface HeatmapChartProps {
    */
   showCellBorders?: boolean;
   /**
+   * Border configuration for individual control over borders
+   * Use this for directional borders (e.g., only left/right for column separation)
+   */
+  cellBorderConfig?: {
+    borderColor?: string;
+    borderWidth?: number | [number, number, number, number]; // [top, right, bottom, left]
+  };
+  /**
    * X-axis title
    */
   xAxisTitle?: string;

--- a/src/pages/ethereum/live/components/BottomBar/BottomBar.tsx
+++ b/src/pages/ethereum/live/components/BottomBar/BottomBar.tsx
@@ -51,11 +51,7 @@ function BottomBarComponent({
           )}
 
           {showDataColumnAvailability && (
-            <DataColumnDataAvailability
-              blobCount={dataColumnBlobCount}
-              firstSeenData={dataColumnFirstSeenData}
-              maxTime={12000}
-            />
+            <DataColumnDataAvailability blobCount={dataColumnBlobCount} firstSeenData={dataColumnFirstSeenData} />
           )}
 
           {!showBlobAvailability && !showDataColumnAvailability && (
@@ -109,11 +105,7 @@ function BottomBarComponent({
             )}
             {showDataColumnAvailability && (
               <TabPanel className="h-full">
-                <DataColumnDataAvailability
-                  blobCount={dataColumnBlobCount}
-                  firstSeenData={dataColumnFirstSeenData}
-                  maxTime={12000}
-                />
+                <DataColumnDataAvailability blobCount={dataColumnBlobCount} firstSeenData={dataColumnFirstSeenData} />
               </TabPanel>
             )}
             <TabPanel className="h-full">

--- a/src/pages/ethereum/live/components/DataColumnDataAvailability/DataColumnDataAvailability.tsx
+++ b/src/pages/ethereum/live/components/DataColumnDataAvailability/DataColumnDataAvailability.tsx
@@ -11,12 +11,10 @@ import { getDataVizColors } from '@/utils/dataVizColors';
  * Displays a heatmap showing when each data column was first seen:
  * - X-axis: 128 data columns (0-127)
  * - Y-axis: Blobs (shows range "0 → n" when >6 blobs, individual labels otherwise)
- * - Cell color: Time when column was first seen with 4000ms deadline
- *   - 0-1000ms: Green (very early)
- *   - 1000-2000ms: Lime (early)
- *   - 2000-3000ms: Yellow (on time)
- *   - 3000-4000ms: Orange (cutting it close)
- *   - >4000ms: Red (missed deadline)
+ * - Cell color: Continuous gradient based on time when column was first seen
+ *   - Green (0ms) → Yellow (2000ms) → Red (4000ms)
+ *   - 1px spacing between columns for better visibility
+ *   - 4000ms deadline for "on time" determination
  * - Each row shows the same column data (columns are independent of blobs)
  * - Fixed height of 400px regardless of blob count
  *
@@ -44,7 +42,7 @@ import { getDataVizColors } from '@/utils/dataVizColors';
 function DataColumnDataAvailabilityComponent({
   blobCount,
   firstSeenData = [],
-  maxTime = 12000,
+  maxTime = 4000,
   className,
 }: DataColumnDataAvailabilityProps): JSX.Element {
   const { PERFORMANCE_TIME_COLORS } = getDataVizColors();
@@ -104,15 +102,16 @@ function DataColumnDataAvailabilityComponent({
           height="100%"
           min={0}
           max={maxTime}
-          visualMapType="piecewise"
-          piecewisePieces={[
-            { min: 0, max: 1000, color: PERFORMANCE_TIME_COLORS.excellent, label: '0-1s' },
-            { min: 1000, max: 2000, color: PERFORMANCE_TIME_COLORS.good, label: '1-2s' },
-            { min: 2000, max: 3000, color: PERFORMANCE_TIME_COLORS.fair, label: '2-3s' },
-            { min: 3000, max: 4000, color: PERFORMANCE_TIME_COLORS.slow, label: '3-4s' },
-            { min: 4000, color: PERFORMANCE_TIME_COLORS.poor, label: '>4s' },
+          visualMapType="continuous"
+          colorGradient={[
+            PERFORMANCE_TIME_COLORS.excellent,
+            PERFORMANCE_TIME_COLORS.good,
+            PERFORMANCE_TIME_COLORS.fair,
+            PERFORMANCE_TIME_COLORS.slow,
+            PERFORMANCE_TIME_COLORS.poor,
           ]}
           showVisualMap={true}
+          showCellBorders={true}
           animationDuration={0}
           emphasisDisabled={false}
           tooltipFormatter={(params, xLabels, yLabels) => {

--- a/src/pages/ethereum/live/components/DataColumnDataAvailability/DataColumnDataAvailability.types.ts
+++ b/src/pages/ethereum/live/components/DataColumnDataAvailability/DataColumnDataAvailability.types.ts
@@ -34,7 +34,7 @@ export interface DataColumnDataAvailabilityProps {
   firstSeenData?: DataColumnFirstSeenPoint[];
   /**
    * Maximum time value for color scale (in milliseconds)
-   * @default 12000
+   * @default 4000
    */
   maxTime?: number;
   /**


### PR DESCRIPTION
## Summary

Enhanced the PeerDAS data column availability heatmap with better visual clarity and improved UX:

- **Continuous gradient**: Replaced discrete color bands with smooth green-to-red gradient (0s-4s range) for more intuitive time representation
- **Better spacing**: Added 2px cell borders for clearer column separation
- **Fixed range**: Corrected max time default from 12000ms to 4000ms to match PeerDAS deadline
- **Cleaner UI**: Updated visual map labels to show "4s"/"0s" and removed obnoxious hover shadow effect

## Testing

- Build and lint pass
- Heatmap renders with correct color gradient and spacing
- Hover state shows subtle border highlight