### PR TITLE
Fix attestation vote percentage calculation

### DIFF
--- a/src/pages/ethereum/slots/DetailPage.tsx
+++ b/src/pages/ethereum/slots/DetailPage.tsx
@@ -731,10 +731,7 @@ export function DetailPage(): JSX.Element {
                   attestationData={allAttestationVotes}
                   currentSlot={slot}
                   votedForBlocks={data.votedForBlocks}
-                  expectedValidatorCount={data.committees.reduce(
-                    (sum, committee) => sum + (committee.validators?.length ?? 0),
-                    0
-                  )}
+                  expectedValidatorCount={totalExpectedValidators}
                   isLoading={attestationVotesLoading}
                 />
                 <AttestationArrivalsChart


### PR DESCRIPTION
## Summary
Fixes attestation vote percentages exceeding 100% by using the correct expected validator count from `attestationCorrectness.votes_max` instead of summing all committee sizes, which was double-counting validators.

## Changes
- Use `totalExpectedValidators` from attestation correctness data in `AttestationVotesBreakdownTable` component

## Testing
Percentages will now correctly represent the portion of actual expected validators voting for each block root.