### PR TITLE
fix: correct contributor route image paths to xatu section

### DIFF
--- a/src/routes/xatu/contributors.tsx
+++ b/src/routes/xatu/contributors.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute('/xatu/contributors')({
       },
       {
         property: 'og:image',
-        content: '/images/experiments/contributors.png',
+        content: '/images/xatu/contributors.png',
       },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/xatu/contributors` },
       { name: 'twitter:title', content: `Contributors | ${import.meta.env.VITE_BASE_TITLE}` },
@@ -36,7 +36,7 @@ export const Route = createFileRoute('/xatu/contributors')({
       },
       {
         name: 'twitter:image',
-        content: '/images/experiments/contributors.png',
+        content: '/images/xatu/contributors.png',
       },
     ],
   }),

--- a/src/routes/xatu/contributors/$id.tsx
+++ b/src/routes/xatu/contributors/$id.tsx
@@ -33,11 +33,11 @@ export const Route = createFileRoute('/xatu/contributors/$id')({
       { property: 'og:type', content: 'website' },
       { property: 'og:title', content: `${ctx.params.id} | ${import.meta.env.VITE_BASE_TITLE}` },
       { property: 'og:description', content: 'Detailed contribution metrics and live network performance data' },
-      { property: 'og:image', content: '/images/experiments/contributors.png' },
+      { property: 'og:image', content: '/images/xatu/contributors.png' },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/xatu/contributors/${ctx.params.id}` },
       { name: 'twitter:title', content: `${ctx.params.id} | ${import.meta.env.VITE_BASE_TITLE}` },
       { name: 'twitter:description', content: 'Detailed contribution metrics and live network performance data' },
-      { name: 'twitter:image', content: '/images/experiments/contributors.png' },
+      { name: 'twitter:image', content: '/images/xatu/contributors.png' },
     ],
   }),
 });


### PR DESCRIPTION
## Summary

Fixed the build validation error by correcting image path references in the xatu contributor routes. The routes were pointing to a non-existent `/images/experiments/contributors.png` instead of the actual image location at `/images/xatu/contributors.png`.

## Changes

- Updated og:image and twitter:image meta tags in `/xatu/contributors` route
- Updated og:image and twitter:image meta tags in `/xatu/contributors/$id` route

The validation plugin now passes successfully and the build completes without errors.