### PR TITLE
refactor: remove experimental language from text

### DIFF
--- a/src/components/Layout/ListContainer/ListSection.stories.tsx
+++ b/src/components/Layout/ListContainer/ListSection.stories.tsx
@@ -136,8 +136,8 @@ export const Collapsible: Story = {
           </a>
         </ListItem>
         <ListItem>
-          <a href="#experimental" className="block px-2.5 py-1.5 text-sm font-semibold text-muted hover:text-primary">
-            Experimental
+          <a href="#beta" className="block px-2.5 py-1.5 text-sm font-semibold text-muted hover:text-primary">
+            Beta
           </a>
         </ListItem>
       </ListSection>

--- a/src/components/Navigation/Tab/Tab.stories.tsx
+++ b/src/components/Navigation/Tab/Tab.stories.tsx
@@ -125,7 +125,7 @@ export const CustomBadges: Story = {
     <TabGroup>
       <TabList className="flex gap-2 border-b border-border">
         <Tab badge={<span className="text-success">New</span>}>Features</Tab>
-        <Tab badge={<span className="text-warning">Beta</span>}>Experiments</Tab>
+        <Tab badge={<span className="text-warning">Beta</span>}>Beta</Tab>
         <Tab>Stable</Tab>
       </TabList>
       <TabPanels className="mt-4">
@@ -135,9 +135,7 @@ export const CustomBadges: Story = {
           </div>
         </TabPanel>
         <TabPanel>
-          <div className="rounded-sm border border-border bg-background p-4 text-sm text-foreground">
-            Experimental features
-          </div>
+          <div className="rounded-sm border border-border bg-background p-4 text-sm text-foreground">Beta features</div>
         </TabPanel>
         <TabPanel>
           <div className="rounded-sm border border-border bg-background p-4 text-sm text-foreground">

--- a/src/pages/home/components/AlgorithmicArt/AlgorithmicArt.tsx
+++ b/src/pages/home/components/AlgorithmicArt/AlgorithmicArt.tsx
@@ -11,7 +11,7 @@
  *   seed={12345}
  *   showOverlay
  *   overlayTitle="Welcome to The Lab"
- *   overlaySubtitle="Experimental Ethereum data visualizations"
+ *   overlaySubtitle="Ethereum data visualizations"
  * />
  * ```
  */

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -238,13 +238,13 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
         name: 'viewport',
         content: 'width=device-width, initial-scale=1.0, maximum-scale=5.0',
       },
-      { name: 'description', content: 'Experimental platform for exploring Ethereum data and network statistics.' },
+      { name: 'description', content: 'Platform for exploring Ethereum data and network statistics.' },
 
       // Schema.org (For Google+)
       { itemProp: 'name', content: import.meta.env.VITE_BASE_TITLE },
       {
         itemProp: 'description',
-        content: 'Experimental platform for exploring Ethereum data and network statistics.',
+        content: 'Platform for exploring Ethereum data and network statistics.',
       },
       { itemProp: 'image', content: '/images/header.png' },
 
@@ -255,7 +255,7 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
       { name: 'twitter:title', content: import.meta.env.VITE_BASE_TITLE },
       {
         name: 'twitter:description',
-        content: 'Experimental platform for exploring Ethereum data and network statistics.',
+        content: 'Platform for exploring Ethereum data and network statistics.',
       },
       { name: 'twitter:site', content: '@ethpandaops' },
       { name: 'twitter:image', content: '/images/header.png' },
@@ -267,7 +267,7 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
       { property: 'og:title', content: import.meta.env.VITE_BASE_TITLE },
       {
         property: 'og:description',
-        content: 'Experimental platform for exploring Ethereum data and network statistics.',
+        content: 'Platform for exploring Ethereum data and network statistics.',
       },
       { property: 'og:image', content: '/images/header.png' },
       { property: 'og:locale', content: 'en_US' },

--- a/src/routes/experiments.tsx
+++ b/src/routes/experiments.tsx
@@ -14,14 +14,14 @@ export const Route = createFileRoute('/experiments')({
       },
       {
         name: 'description',
-        content: 'Explore experimental visualizations and data analysis tools for Ethereum and Xatu networks.',
+        content: 'Explore visualizations and data analysis tools for Ethereum and Xatu networks.',
       },
       { property: 'og:url', content: `${import.meta.env.VITE_BASE_URL}/experiments` },
       { property: 'og:type', content: 'website' },
       { property: 'og:title', content: `Experiments | ${import.meta.env.VITE_BASE_TITLE}` },
       {
         property: 'og:description',
-        content: 'Explore experimental visualizations and data analysis tools for Ethereum and Xatu networks.',
+        content: 'Explore visualizations and data analysis tools for Ethereum and Xatu networks.',
       },
       {
         property: 'og:image',
@@ -31,7 +31,7 @@ export const Route = createFileRoute('/experiments')({
       { name: 'twitter:title', content: `Experiments | ${import.meta.env.VITE_BASE_TITLE}` },
       {
         name: 'twitter:description',
-        content: 'Explore experimental visualizations and data analysis tools for Ethereum and Xatu networks.',
+        content: 'Explore visualizations and data analysis tools for Ethereum and Xatu networks.',
       },
       {
         name: 'twitter:image',

--- a/src/routes/experiments/index.tsx
+++ b/src/routes/experiments/index.tsx
@@ -10,14 +10,14 @@ export const Route = createFileRoute('/experiments/')({
       },
       {
         name: 'description',
-        content: 'Explore experimental visualizations and data analysis tools for Ethereum and Xatu networks.',
+        content: 'Explore visualizations and data analysis tools for Ethereum and Xatu networks.',
       },
       { property: 'og:url', content: `${import.meta.env.VITE_BASE_URL}/experiments` },
       { property: 'og:type', content: 'website' },
       { property: 'og:title', content: `Experiments | ${import.meta.env.VITE_BASE_TITLE}` },
       {
         property: 'og:description',
-        content: 'Explore experimental visualizations and data analysis tools for Ethereum and Xatu networks.',
+        content: 'Explore visualizations and data analysis tools for Ethereum and Xatu networks.',
       },
       {
         property: 'og:image',
@@ -27,7 +27,7 @@ export const Route = createFileRoute('/experiments/')({
       { name: 'twitter:title', content: `Experiments | ${import.meta.env.VITE_BASE_TITLE}` },
       {
         name: 'twitter:description',
-        content: 'Explore experimental visualizations and data analysis tools for Ethereum and Xatu networks.',
+        content: 'Explore visualizations and data analysis tools for Ethereum and Xatu networks.',
       },
       {
         name: 'twitter:image',

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -10,14 +10,14 @@ export const Route = createFileRoute('/')({
       },
       {
         name: 'description',
-        content: 'Experimental platform for exploring Ethereum data and network statistics.',
+        content: 'Platform for exploring Ethereum data and network statistics.',
       },
       { property: 'og:url', content: `${import.meta.env.VITE_BASE_URL}/` },
       { property: 'og:type', content: 'website' },
       { property: 'og:title', content: import.meta.env.VITE_BASE_TITLE },
       {
         property: 'og:description',
-        content: 'Experimental platform for exploring Ethereum data and network statistics.',
+        content: 'Platform for exploring Ethereum data and network statistics.',
       },
       {
         property: 'og:image',
@@ -27,7 +27,7 @@ export const Route = createFileRoute('/')({
       { name: 'twitter:title', content: import.meta.env.VITE_BASE_TITLE },
       {
         name: 'twitter:description',
-        content: 'Experimental platform for exploring Ethereum data and network statistics.',
+        content: 'Platform for exploring Ethereum data and network statistics.',
       },
       {
         name: 'twitter:image',


### PR DESCRIPTION
## Summary
Removes "experimental" terminology from page descriptions and example content, reflecting that The Lab is no longer in beta. Updates route meta tags (descriptions for OpenGraph, Twitter, and Schema.org) and story examples.

## Changes
- Route meta descriptions updated to remove "experimental" qualifier
- Story component examples updated (changed "Experiments" tab to "Beta", "Experimental" to "Beta features")
- JSDoc example updated

All content now accurately reflects The Lab's stable status.