### PR TITLE
feat: add GitHub and Twitter links to sidebar

### DIFF
--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -10,6 +10,42 @@ import { useConfig } from '@/hooks/useConfig';
 import { useNetwork } from '@/hooks/useNetwork';
 import type { SidebarProps } from './Sidebar.types';
 
+/**
+ * Social links component for the sidebar footer
+ */
+function SocialLinks(): JSX.Element {
+  return (
+    <div className="flex items-center justify-center gap-4 border-t border-border/50 py-4">
+      <a
+        href="https://github.com/ethpandaops/lab"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-muted transition-colors hover:text-foreground"
+        aria-label="GitHub repository"
+      >
+        <svg className="size-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            fillRule="evenodd"
+            d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </a>
+      <a
+        href="https://twitter.com/ethpandaops"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-muted transition-colors hover:text-foreground"
+        aria-label="Twitter profile"
+      >
+        <svg className="size-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+        </svg>
+      </a>
+    </div>
+  );
+}
+
 interface NavItem {
   name: string;
   to: string;
@@ -103,102 +139,109 @@ export function Sidebar({ sidebarOpen, setSidebarOpen }: SidebarProps): JSX.Elem
             className="relative flex w-full flex-1 transform transition duration-300 ease-in-out data-closed:-translate-x-full"
           >
             {/* Mobile sidebar content */}
-            <div className="relative flex grow flex-col gap-y-5 overflow-y-auto bg-surface/95 px-6 pt-4 pb-2 backdrop-blur-xl">
-              <nav className="flex flex-1 flex-col">
-                <ListContainer variant="simple" withDividers={false} compact className="flex flex-1 flex-col gap-y-7">
-                  {/* Network Selector */}
-                  <ListItem>
-                    <Header size="xs" title="Network" />
-                    <div className="mt-2">
-                      <NetworkSelect showLabel={false} />
-                    </div>
-                  </ListItem>
+            <div className="relative flex grow flex-col bg-surface/95 backdrop-blur-xl">
+              <div className="flex grow flex-col gap-y-5 overflow-y-auto px-6 pt-4">
+                <nav className="flex flex-1 flex-col">
+                  <ListContainer variant="simple" withDividers={false} compact className="flex flex-1 flex-col gap-y-7">
+                    {/* Network Selector */}
+                    <ListItem>
+                      <Header size="xs" title="Network" />
+                      <div className="mt-2">
+                        <NetworkSelect showLabel={false} />
+                      </div>
+                    </ListItem>
 
-                  {/* Ethereum Section */}
-                  <ListSection title="Ethereum">
-                    {filteredEthereumConsensusPages.length > 0 && (
-                      <ListSection title="Consensus" nested>
-                        {filteredEthereumConsensusPages.map(page => (
-                          <ListItem key={page.to}>
-                            <Link
-                              to={page.to}
-                              preload="viewport"
-                              preloadDelay={100}
-                              className="group flex gap-x-3 rounded-lg px-2.5 py-2 text-base font-semibold text-muted transition-all hover:bg-primary/10 hover:text-primary lg:py-1.5 lg:text-sm/6"
-                              activeProps={{
-                                className: 'bg-primary/10 text-primary shadow-sm ring-1 ring-primary/20',
-                              }}
-                            >
-                              {page.name}
-                            </Link>
-                          </ListItem>
-                        ))}
-                      </ListSection>
-                    )}
+                    {/* Ethereum Section */}
+                    <ListSection title="Ethereum">
+                      {filteredEthereumConsensusPages.length > 0 && (
+                        <ListSection title="Consensus" nested>
+                          {filteredEthereumConsensusPages.map(page => (
+                            <ListItem key={page.to}>
+                              <Link
+                                to={page.to}
+                                preload="viewport"
+                                preloadDelay={100}
+                                className="group flex gap-x-3 rounded-lg px-2.5 py-2 text-base font-semibold text-muted transition-all hover:bg-primary/10 hover:text-primary lg:py-1.5 lg:text-sm/6"
+                                activeProps={{
+                                  className: 'bg-primary/10 text-primary shadow-sm ring-1 ring-primary/20',
+                                }}
+                              >
+                                {page.name}
+                              </Link>
+                            </ListItem>
+                          ))}
+                        </ListSection>
+                      )}
 
-                    {filteredEthereumExecutionPages.length > 0 && (
-                      <ListSection title="Execution" nested>
-                        {filteredEthereumExecutionPages.map(page => (
-                          <ListItem key={page.to}>
-                            <Link
-                              to={page.to}
-                              preload="viewport"
-                              preloadDelay={100}
-                              className="group flex gap-x-3 rounded-lg px-2.5 py-2 text-base font-semibold text-muted transition-all hover:bg-primary/10 hover:text-primary lg:py-1.5 lg:text-sm/6"
-                              activeProps={{
-                                className: 'bg-primary/10 text-primary shadow-sm ring-1 ring-primary/20',
-                              }}
-                            >
-                              {page.name}
-                            </Link>
-                          </ListItem>
-                        ))}
-                      </ListSection>
-                    )}
+                      {filteredEthereumExecutionPages.length > 0 && (
+                        <ListSection title="Execution" nested>
+                          {filteredEthereumExecutionPages.map(page => (
+                            <ListItem key={page.to}>
+                              <Link
+                                to={page.to}
+                                preload="viewport"
+                                preloadDelay={100}
+                                className="group flex gap-x-3 rounded-lg px-2.5 py-2 text-base font-semibold text-muted transition-all hover:bg-primary/10 hover:text-primary lg:py-1.5 lg:text-sm/6"
+                                activeProps={{
+                                  className: 'bg-primary/10 text-primary shadow-sm ring-1 ring-primary/20',
+                                }}
+                              >
+                                {page.name}
+                              </Link>
+                            </ListItem>
+                          ))}
+                        </ListSection>
+                      )}
 
-                    {filteredEthereumDataAvailabilityPages.length > 0 && (
-                      <ListSection title="Data Availability" nested className="mt-4">
-                        {filteredEthereumDataAvailabilityPages.map(page => (
-                          <ListItem key={page.to}>
-                            <Link
-                              to={page.to}
-                              preload="viewport"
-                              preloadDelay={100}
-                              className="group flex gap-x-3 rounded-lg px-2.5 py-2 text-base font-semibold text-muted transition-all hover:bg-primary/10 hover:text-primary lg:py-1.5 lg:text-sm/6"
-                              activeProps={{
-                                className: 'bg-primary/10 text-primary shadow-sm ring-1 ring-primary/20',
-                              }}
-                            >
-                              {page.name}
-                            </Link>
-                          </ListItem>
-                        ))}
-                      </ListSection>
-                    )}
-                  </ListSection>
-
-                  {/* Xatu Section */}
-                  {filteredXatuPages.length > 0 && (
-                    <ListSection title="Xatu">
-                      {filteredXatuPages.map(page => (
-                        <ListItem key={page.to}>
-                          <Link
-                            to={page.to}
-                            preload="viewport"
-                            preloadDelay={100}
-                            className="group flex gap-x-3 rounded-lg px-2.5 py-2 text-base font-semibold text-muted transition-all hover:bg-primary/10 hover:text-primary lg:py-1.5 lg:text-sm/6"
-                            activeProps={{
-                              className: 'bg-primary/10 text-primary shadow-sm ring-1 ring-primary/20',
-                            }}
-                          >
-                            {page.name}
-                          </Link>
-                        </ListItem>
-                      ))}
+                      {filteredEthereumDataAvailabilityPages.length > 0 && (
+                        <ListSection title="Data Availability" nested className="mt-4">
+                          {filteredEthereumDataAvailabilityPages.map(page => (
+                            <ListItem key={page.to}>
+                              <Link
+                                to={page.to}
+                                preload="viewport"
+                                preloadDelay={100}
+                                className="group flex gap-x-3 rounded-lg px-2.5 py-2 text-base font-semibold text-muted transition-all hover:bg-primary/10 hover:text-primary lg:py-1.5 lg:text-sm/6"
+                                activeProps={{
+                                  className: 'bg-primary/10 text-primary shadow-sm ring-1 ring-primary/20',
+                                }}
+                              >
+                                {page.name}
+                              </Link>
+                            </ListItem>
+                          ))}
+                        </ListSection>
+                      )}
                     </ListSection>
-                  )}
-                </ListContainer>
-              </nav>
+
+                    {/* Xatu Section */}
+                    {filteredXatuPages.length > 0 && (
+                      <ListSection title="Xatu">
+                        {filteredXatuPages.map(page => (
+                          <ListItem key={page.to}>
+                            <Link
+                              to={page.to}
+                              preload="viewport"
+                              preloadDelay={100}
+                              className="group flex gap-x-3 rounded-lg px-2.5 py-2 text-base font-semibold text-muted transition-all hover:bg-primary/10 hover:text-primary lg:py-1.5 lg:text-sm/6"
+                              activeProps={{
+                                className: 'bg-primary/10 text-primary shadow-sm ring-1 ring-primary/20',
+                              }}
+                            >
+                              {page.name}
+                            </Link>
+                          </ListItem>
+                        ))}
+                      </ListSection>
+                    )}
+                  </ListContainer>
+                </nav>
+              </div>
+
+              {/* Social Links Footer */}
+              <div className="shrink-0 px-6">
+                <SocialLinks />
+              </div>
             </div>
           </DialogPanel>
         </div>
@@ -206,6 +249,7 @@ export function Sidebar({ sidebarOpen, setSidebarOpen }: SidebarProps): JSX.Elem
 
       {/* Static sidebar for desktop */}
       <div className="hidden border-r border-border bg-surface/95 backdrop-blur-xl lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
+        {/* Scrollable content */}
         <div className="flex grow flex-col gap-y-5 overflow-y-auto px-6">
           {/* Logo and Theme Toggle */}
           <div className="flex h-16 shrink-0 items-center justify-between border-b border-border/50">
@@ -314,6 +358,11 @@ export function Sidebar({ sidebarOpen, setSidebarOpen }: SidebarProps): JSX.Elem
               )}
             </ListContainer>
           </nav>
+        </div>
+
+        {/* Social Links Footer - Fixed at bottom */}
+        <div className="shrink-0 px-6">
+          <SocialLinks />
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
Adds a static social links section at the bottom of both mobile and desktop sidebars with icons linking to ethpandaops GitHub repository and Twitter profile. The footer remains fixed at the bottom while the main navigation scrolls.

## Changes
- Created `SocialLinks` component with GitHub and Twitter icons
- Added footer to both mobile and desktop sidebar layouts
- Used semantic color tokens for consistent theming
- Proper accessibility with aria-labels and semantic HTML

## Testing
- Linting and build validation passed
- Social links appear at the bottom of sidebar on both mobile and desktop
- Icons have proper hover states and styling