### PR TITLE
fix: correct logo aspect ratio in sidebar and mobile header

### DIFF
--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -210,7 +210,7 @@ export function Sidebar({ sidebarOpen, setSidebarOpen }: SidebarProps): JSX.Elem
           {/* Logo and Theme Toggle */}
           <div className="flex h-16 shrink-0 items-center justify-between border-b border-border/50">
             <Link to="/" className="flex items-center gap-3 transition-opacity hover:opacity-80">
-              <img alt="Lab Logo" src="/images/lab.png" className="size-10" />
+              <img alt="Lab Logo" src="/images/lab.png" className="h-10 w-auto" />
               <div className="flex flex-col justify-center">
                 <span className="font-sans text-2xl font-bold text-foreground">The Lab</span>
                 <span className="-mt-1 text-[12px] text-muted">lab.ethpandaops.io</span>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -99,7 +99,7 @@ function MobileHeader({
           <span className="h-0.5 w-6 origin-center rounded-full bg-muted transition-all duration-300 ease-out group-hover:bg-foreground group-[[aria-pressed=true]]:-translate-y-2 group-[[aria-pressed=true]]:-rotate-45" />
         </button>
         <Link to="/" className="flex items-center gap-2">
-          <img alt="Lab Logo" src="/images/lab.png" className="size-8" />
+          <img alt="Lab Logo" src="/images/lab.png" className="h-8 w-auto" />
           <span className="font-sans text-xl font-bold text-foreground">The Lab</span>
         </Link>
       </div>


### PR DESCRIPTION
Previously logos were stretched horizontally due to using size-* classes that forced square dimensions. Changed to h-* w-auto to maintain proper aspect ratio while fitting height requirements.