### PR TITLE
fix: clear map datapoints when slot ends

### DIFF
--- a/src/components/Charts/Map2D/Map2D.tsx
+++ b/src/components/Charts/Map2D/Map2D.tsx
@@ -168,8 +168,15 @@ function Map2DChartComponent({
       previousPointsLengthRef.current = 0;
     }
 
-    // Early exit: if points array length hasn't changed and we're not resetting, skip
-    if (!isReset && points.length === previousPointsLengthRef.current) {
+    // If points array is empty, clear accumulated points (slot ended)
+    const isClearing = points.length === 0 && allSeenPointsRef.current.size > 0;
+    if (isClearing) {
+      allSeenPointsRef.current.clear();
+      previousPointsLengthRef.current = 0;
+    }
+
+    // Early exit: if points array length hasn't changed and we're not resetting or clearing, skip
+    if (!isReset && !isClearing && points.length === previousPointsLengthRef.current) {
       return;
     }
 
@@ -194,8 +201,8 @@ function Map2DChartComponent({
       }
     });
 
-    // Only update if we have new points or just reset
-    if (!hasNewPoints && !isReset) return;
+    // Only update if we have new points, just reset, or clearing
+    if (!hasNewPoints && !isReset && !isClearing) return;
 
     // Update our tracking ref
     previousPointsLengthRef.current = points.length;


### PR DESCRIPTION
## Summary
Fixes an issue where active node datapoints on the live slot view map were not disappearing when the slot ended. The map now properly clears accumulated points when transitioning between slots.

## Changes
- Added explicit clearing logic in Map2D component to detect when points array becomes empty
- Clears accumulated points when slot ends to ensure clean visualization for next slot
- Updated early exit and update conditions to handle the clearing state

## Testing
- Lint and build passed
- Verified on live slot view page that datapoints disappear as expected when slot ends