### PR TITLE
fix: filter offline validators by missed_count > 0 at API level

### DIFF
--- a/src/pages/ethereum/epochs/hooks/useEpochDetailData.ts
+++ b/src/pages/ethereum/epochs/hooks/useEpochDetailData.ts
@@ -123,6 +123,7 @@ export function useEpochDetailData(epoch: number, isLive = false): UseEpochDetai
           query: {
             slot_gte: firstSlot,
             slot_lte: lastSlot,
+            missed_count_gt: 0,
             page_size: 10000,
           },
         }),
@@ -315,13 +316,12 @@ export function useEpochDetailData(epoch: number, isLive = false): UseEpochDetai
     };
 
     // Process missed attestations by entity
-    const missedAttestationsByEntity: SlotMissedAttestationEntity[] = attestationLivenessData
-      .filter(record => (record.missed_count ?? 0) > 0)
-      .map(record => ({
-        slot: record.slot ?? 0,
-        entity: record.entity ?? 'unknown',
-        count: record.missed_count ?? 0,
-      }));
+    // Note: API query already filters for missed_count > 0
+    const missedAttestationsByEntity: SlotMissedAttestationEntity[] = attestationLivenessData.map(record => ({
+      slot: record.slot ?? 0,
+      entity: record.entity ?? 'unknown',
+      count: record.missed_count ?? 0,
+    }));
 
     // Calculate top 10 entities by total missed attestations
     const entityTotals = new Map<string, number>();


### PR DESCRIPTION
## Summary
Add `missed_count_gt` filter to the attestation liveness API query to only fetch validators with missed attestations. This filters offline validators server-side instead of client-side, improving query efficiency.

## Changes
- Added `missed_count_gt: 0` parameter to the `fctAttestationLivenessByEntityHeadServiceListOptions` API query
- Removed redundant client-side `.filter()` operation since the API now handles filtering

## Test plan
- View epoch 407262 validators tab and verify only offline validators are displayed
- Verify no functionality changes - same data displayed, just more efficient