### PR TITLE
fix(ForksHeader): show proper time-unit labels while countdown is loa…

### DIFF
--- a/src/pages/ethereum/forks/components/ForksHeader/ForksHeader.tsx
+++ b/src/pages/ethereum/forks/components/ForksHeader/ForksHeader.tsx
@@ -47,7 +47,7 @@ export function ForksHeader({ activeFork, nextFork, allForks }: ForksHeaderProps
   useEffect(() => {
     if (!nextFork || !currentNetwork?.genesis_time) return;
 
-    const updateCountdown = () => {
+    const updateCountdown = (): void => {
       const secondsUntilFork = calculateSecondsUntilFork();
 
       setCountdown({


### PR DESCRIPTION
call updateInterval immediately - it waited for the first 1-second interval, meaning it loaded 0:0:0:0 for a second and was breaking my mind