### PR TITLE
fix(MultiLine): enable chart updates when toggling series visibility

### DIFF
--- a/src/components/Charts/MultiLine/MultiLine.tsx
+++ b/src/components/Charts/MultiLine/MultiLine.tsx
@@ -86,6 +86,7 @@ export function MultiLineChart({
   enableSeriesFilter = false,
   relativeSlots,
   syncGroup,
+  notMerge = true,
 }: MultiLineChartProps): React.JSX.Element {
   // Get callback ref for crosshair sync
   const chartRef = useSharedCrosshairs({ syncGroup });
@@ -767,7 +768,7 @@ export function MultiLineChart({
             minHeight: typeof _height === 'number' && !(showLegend && series.length > 1) ? _height + 52 : _height,
             pointerEvents: 'auto',
           }}
-          notMerge={true}
+          notMerge={notMerge}
           opts={{ renderer: 'canvas' }}
         />
       </div>

--- a/src/components/Charts/MultiLine/MultiLine.types.ts
+++ b/src/components/Charts/MultiLine/MultiLine.types.ts
@@ -302,4 +302,11 @@ export interface MultiLineChartProps {
    * Charts with the same syncGroup will have synchronized tooltips and axis pointers
    */
   syncGroup?: string;
+  /**
+   * Whether to merge or replace chart options on update
+   * When true, completely replaces chart options (recommended for toggling series)
+   * When false, merges new options with existing chart state (better performance for frequent updates)
+   * @default true
+   */
+  notMerge?: boolean;
 }

--- a/src/pages/ethereum/live/components/BlobDataAvailability/BlobDataAvailability.tsx
+++ b/src/pages/ethereum/live/components/BlobDataAvailability/BlobDataAvailability.tsx
@@ -186,6 +186,7 @@ function BlobDataAvailabilityComponent({
             tooltipTrigger="axis"
             tooltipFormatter={continentalTooltipFormatter}
             animationDuration={0}
+            notMerge={false}
           />
         </div>
       </div>
@@ -232,6 +233,7 @@ function BlobDataAvailabilityComponent({
               tooltipTrigger="axis"
               tooltipFormatter={continentalTooltipFormatter}
               animationDuration={0}
+              notMerge={false}
             />
           </div>
         </div>
@@ -248,6 +250,7 @@ function BlobDataAvailabilityComponent({
           tooltipTrigger="axis"
           tooltipFormatter={continentalTooltipFormatter}
           animationDuration={0}
+          notMerge={false}
         />
       </div>
     </>


### PR DESCRIPTION
Set notMerge to true on ReactEChartsCore to ensure chart properly updates when series are toggled via legend. Previously, with notMerge=false, ECharts would merge options instead of replacing them, causing hidden series to remain visible on the chart.