### PR TITLE
fix: use canonical URLs with VITE_BASE_URL for all og:image and twitt…

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -246,7 +246,7 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
         itemProp: 'description',
         content: 'Platform for exploring Ethereum data and network statistics.',
       },
-      { itemProp: 'image', content: '/images/header.png' },
+      { itemProp: 'image', content: `${import.meta.env.VITE_BASE_URL}/images/header.png` },
 
       // Twitter Card markup
       { name: 'twitter:card', content: 'summary_large_image' },
@@ -258,7 +258,7 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
         content: 'Platform for exploring Ethereum data and network statistics.',
       },
       { name: 'twitter:site', content: '@ethpandaops' },
-      { name: 'twitter:image', content: '/images/header.png' },
+      { name: 'twitter:image', content: `${import.meta.env.VITE_BASE_URL}/images/header.png` },
       { name: 'twitter:image:alt', content: import.meta.env.VITE_BASE_TITLE },
 
       // Open Graph markup (Facebook)
@@ -269,7 +269,7 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
         property: 'og:description',
         content: 'Platform for exploring Ethereum data and network statistics.',
       },
-      { property: 'og:image', content: '/images/header.png' },
+      { property: 'og:image', content: `${import.meta.env.VITE_BASE_URL}/images/header.png` },
       { property: 'og:locale', content: 'en_US' },
       { property: 'og:site_name', content: import.meta.env.VITE_BASE_TITLE },
     ],

--- a/src/routes/ethereum/data-availability/custody.tsx
+++ b/src/routes/ethereum/data-availability/custody.tsx
@@ -22,14 +22,20 @@ export const Route = createFileRoute('/ethereum/data-availability/custody')({
         property: 'og:description',
         content: 'PeerDAS data availability visualization showing column custody across validators',
       },
-      { property: 'og:image', content: '/images/ethereum/data-availability/custody.png' },
+      {
+        property: 'og:image',
+        content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/data-availability/custody.png`,
+      },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/ethereum/data-availability/custody` },
       { name: 'twitter:title', content: `Custody | ${import.meta.env.VITE_BASE_TITLE}` },
       {
         name: 'twitter:description',
         content: 'PeerDAS data availability visualization showing column custody across validators',
       },
-      { name: 'twitter:image', content: '/images/ethereum/data-availability/custody.png' },
+      {
+        name: 'twitter:image',
+        content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/data-availability/custody.png`,
+      },
     ],
   }),
 });

--- a/src/routes/ethereum/data-availability/custody/index.tsx
+++ b/src/routes/ethereum/data-availability/custody/index.tsx
@@ -22,14 +22,20 @@ export const Route = createFileRoute('/ethereum/data-availability/custody/')({
         property: 'og:description',
         content: 'PeerDAS data availability visualization showing column custody across validators',
       },
-      { property: 'og:image', content: '/images/ethereum/data-availability/custody.png' },
+      {
+        property: 'og:image',
+        content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/data-availability/custody.png`,
+      },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/ethereum/data-availability/custody` },
       { name: 'twitter:title', content: `Custody | ${import.meta.env.VITE_BASE_TITLE}` },
       {
         name: 'twitter:description',
         content: 'PeerDAS data availability visualization showing column custody across validators',
       },
-      { name: 'twitter:image', content: '/images/ethereum/data-availability/custody.png' },
+      {
+        name: 'twitter:image',
+        content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/data-availability/custody.png`,
+      },
     ],
   }),
 });

--- a/src/routes/ethereum/epochs.tsx
+++ b/src/routes/ethereum/epochs.tsx
@@ -20,14 +20,14 @@ export const Route = createFileRoute('/ethereum/epochs')({
         property: 'og:description',
         content: 'Explore Ethereum beacon chain epochs. View recent epoch data and dive into detailed epoch analytics.',
       },
-      { property: 'og:image', content: '/images/ethereum/epochs.png' },
+      { property: 'og:image', content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/epochs.png` },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/ethereum/epochs` },
       { name: 'twitter:title', content: `Epochs | ${import.meta.env.VITE_BASE_TITLE}` },
       {
         name: 'twitter:description',
         content: 'Explore Ethereum beacon chain epochs. View recent epoch data and dive into detailed epoch analytics.',
       },
-      { name: 'twitter:image', content: '/images/ethereum/epochs.png' },
+      { name: 'twitter:image', content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/epochs.png` },
     ],
   }),
 });

--- a/src/routes/ethereum/epochs/$epoch.tsx
+++ b/src/routes/ethereum/epochs/$epoch.tsx
@@ -29,7 +29,7 @@ export const Route = createFileRoute('/ethereum/epochs/$epoch')({
         content:
           'Detailed analysis of a beacon chain epoch including attestations, block proposals, and validator performance across all slots.',
       },
-      { property: 'og:image', content: '/images/ethereum/epochs.png' },
+      { property: 'og:image', content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/epochs.png` },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/ethereum/epochs/${ctx.params.epoch}` },
       { name: 'twitter:title', content: `Epoch ${ctx.params.epoch} | ${import.meta.env.VITE_BASE_TITLE}` },
       {
@@ -37,7 +37,7 @@ export const Route = createFileRoute('/ethereum/epochs/$epoch')({
         content:
           'Detailed analysis of a beacon chain epoch including attestations, block proposals, and validator performance across all slots.',
       },
-      { name: 'twitter:image', content: '/images/ethereum/epochs.png' },
+      { name: 'twitter:image', content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/epochs.png` },
     ],
   }),
 });

--- a/src/routes/ethereum/epochs/index.tsx
+++ b/src/routes/ethereum/epochs/index.tsx
@@ -21,14 +21,14 @@ export const Route = createFileRoute('/ethereum/epochs/')({
         property: 'og:description',
         content: 'Explore Ethereum beacon chain epochs. View recent epoch data and dive into detailed epoch analytics.',
       },
-      { property: 'og:image', content: '/images/ethereum/epochs.png' },
+      { property: 'og:image', content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/epochs.png` },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/ethereum/epochs` },
       { name: 'twitter:title', content: `Epochs | ${import.meta.env.VITE_BASE_TITLE}` },
       {
         name: 'twitter:description',
         content: 'Explore Ethereum beacon chain epochs. View recent epoch data and dive into detailed epoch analytics.',
       },
-      { name: 'twitter:image', content: '/images/ethereum/epochs.png' },
+      { name: 'twitter:image', content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/epochs.png` },
     ],
   }),
 });

--- a/src/routes/ethereum/live.tsx
+++ b/src/routes/ethereum/live.tsx
@@ -42,7 +42,7 @@ export const Route = createFileRoute('/ethereum/live')({
       },
       {
         property: 'og:image',
-        content: '/images/ethereum/live.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/live.png`,
       },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/ethereum/live` },
       { name: 'twitter:title', content: `Live | ${import.meta.env.VITE_BASE_TITLE}` },
@@ -52,7 +52,7 @@ export const Route = createFileRoute('/ethereum/live')({
       },
       {
         name: 'twitter:image',
-        content: '/images/ethereum/live.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/live.png`,
       },
     ],
   }),

--- a/src/routes/ethereum/slots.tsx
+++ b/src/routes/ethereum/slots.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute('/ethereum/slots')({
       },
       {
         property: 'og:image',
-        content: '/images/ethereum/slots.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/slots.png`,
       },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/ethereum/slots` },
       { name: 'twitter:title', content: `Slots | ${import.meta.env.VITE_BASE_TITLE}` },
@@ -36,7 +36,7 @@ export const Route = createFileRoute('/ethereum/slots')({
       },
       {
         name: 'twitter:image',
-        content: '/images/ethereum/slots.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/slots.png`,
       },
     ],
   }),

--- a/src/routes/ethereum/slots/$slot.tsx
+++ b/src/routes/ethereum/slots/$slot.tsx
@@ -33,7 +33,7 @@ export const Route = createFileRoute('/ethereum/slots/$slot')({
       },
       {
         property: 'og:image',
-        content: '/images/ethereum/slots.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/slots.png`,
       },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/ethereum/slots/${ctx.params.slot}` },
       { name: 'twitter:title', content: `Slot ${ctx.params.slot} | ${import.meta.env.VITE_BASE_TITLE}` },
@@ -44,7 +44,7 @@ export const Route = createFileRoute('/ethereum/slots/$slot')({
       },
       {
         name: 'twitter:image',
-        content: '/images/ethereum/slots.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/slots.png`,
       },
     ],
   }),

--- a/src/routes/ethereum/slots/index.tsx
+++ b/src/routes/ethereum/slots/index.tsx
@@ -24,7 +24,7 @@ export const Route = createFileRoute('/ethereum/slots/')({
       },
       {
         property: 'og:image',
-        content: '/images/ethereum/slots.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/slots.png`,
       },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/ethereum/slots` },
       { name: 'twitter:title', content: `Slots | ${import.meta.env.VITE_BASE_TITLE}` },
@@ -34,7 +34,7 @@ export const Route = createFileRoute('/ethereum/slots/')({
       },
       {
         name: 'twitter:image',
-        content: '/images/ethereum/slots.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/ethereum/slots.png`,
       },
     ],
   }),

--- a/src/routes/experiments.tsx
+++ b/src/routes/experiments.tsx
@@ -25,7 +25,7 @@ export const Route = createFileRoute('/experiments')({
       },
       {
         property: 'og:image',
-        content: '/images/experiments.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/experiments.png`,
       },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/experiments` },
       { name: 'twitter:title', content: `Experiments | ${import.meta.env.VITE_BASE_TITLE}` },
@@ -35,7 +35,7 @@ export const Route = createFileRoute('/experiments')({
       },
       {
         name: 'twitter:image',
-        content: '/images/experiments.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/experiments.png`,
       },
     ],
   }),

--- a/src/routes/experiments/index.tsx
+++ b/src/routes/experiments/index.tsx
@@ -21,7 +21,7 @@ export const Route = createFileRoute('/experiments/')({
       },
       {
         property: 'og:image',
-        content: '/images/experiments.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/experiments.png`,
       },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/experiments` },
       { name: 'twitter:title', content: `Experiments | ${import.meta.env.VITE_BASE_TITLE}` },
@@ -31,7 +31,7 @@ export const Route = createFileRoute('/experiments/')({
       },
       {
         name: 'twitter:image',
-        content: '/images/experiments.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/experiments.png`,
       },
     ],
   }),

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -21,7 +21,7 @@ export const Route = createFileRoute('/')({
       },
       {
         property: 'og:image',
-        content: '/images/header.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/header.png`,
       },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/` },
       { name: 'twitter:title', content: import.meta.env.VITE_BASE_TITLE },
@@ -31,7 +31,7 @@ export const Route = createFileRoute('/')({
       },
       {
         name: 'twitter:image',
-        content: '/images/header.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/header.png`,
       },
     ],
   }),

--- a/src/routes/xatu/contributors.tsx
+++ b/src/routes/xatu/contributors.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute('/xatu/contributors')({
       },
       {
         property: 'og:image',
-        content: '/images/xatu/contributors.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/xatu/contributors.png`,
       },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/xatu/contributors` },
       { name: 'twitter:title', content: `Contributors | ${import.meta.env.VITE_BASE_TITLE}` },
@@ -36,7 +36,7 @@ export const Route = createFileRoute('/xatu/contributors')({
       },
       {
         name: 'twitter:image',
-        content: '/images/xatu/contributors.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/xatu/contributors.png`,
       },
     ],
   }),

--- a/src/routes/xatu/contributors/$id.tsx
+++ b/src/routes/xatu/contributors/$id.tsx
@@ -33,11 +33,11 @@ export const Route = createFileRoute('/xatu/contributors/$id')({
       { property: 'og:type', content: 'website' },
       { property: 'og:title', content: `${ctx.params.id} | ${import.meta.env.VITE_BASE_TITLE}` },
       { property: 'og:description', content: 'Detailed contribution metrics and live network performance data' },
-      { property: 'og:image', content: '/images/xatu/contributors.png' },
+      { property: 'og:image', content: `${import.meta.env.VITE_BASE_URL}/images/xatu/contributors.png` },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/xatu/contributors/${ctx.params.id}` },
       { name: 'twitter:title', content: `${ctx.params.id} | ${import.meta.env.VITE_BASE_TITLE}` },
       { name: 'twitter:description', content: 'Detailed contribution metrics and live network performance data' },
-      { name: 'twitter:image', content: '/images/xatu/contributors.png' },
+      { name: 'twitter:image', content: `${import.meta.env.VITE_BASE_URL}/images/xatu/contributors.png` },
     ],
   }),
 });

--- a/src/routes/xatu/contributors/index.tsx
+++ b/src/routes/xatu/contributors/index.tsx
@@ -24,7 +24,7 @@ export const Route = createFileRoute('/xatu/contributors/')({
       },
       {
         property: 'og:image',
-        content: '/images/xatu/contributors.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/xatu/contributors.png`,
       },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/xatu/contributors` },
       { name: 'twitter:title', content: `Contributors | ${import.meta.env.VITE_BASE_TITLE}` },
@@ -34,7 +34,7 @@ export const Route = createFileRoute('/xatu/contributors/')({
       },
       {
         name: 'twitter:image',
-        content: '/images/xatu/contributors.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/xatu/contributors.png`,
       },
     ],
   }),

--- a/src/routes/xatu/fork-readiness.tsx
+++ b/src/routes/xatu/fork-readiness.tsx
@@ -24,7 +24,7 @@ export const Route = createFileRoute('/xatu/fork-readiness')({
       },
       {
         property: 'og:image',
-        content: '/images/xatu/fork-readiness.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/xatu/fork-readiness.png`,
       },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/xatu/fork-readiness` },
       { name: 'twitter:title', content: `Fork Readiness | ${import.meta.env.VITE_BASE_TITLE}` },
@@ -34,7 +34,7 @@ export const Route = createFileRoute('/xatu/fork-readiness')({
       },
       {
         name: 'twitter:image',
-        content: '/images/xatu/fork-readiness.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/xatu/fork-readiness.png`,
       },
     ],
   }),

--- a/src/routes/xatu/geographical-checklist.tsx
+++ b/src/routes/xatu/geographical-checklist.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute('/xatu/geographical-checklist')({
       },
       {
         property: 'og:image',
-        content: '/images/xatu/geographical-checklist.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/xatu/geographical-checklist.png`,
       },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/xatu/geographical-checklist` },
       { name: 'twitter:title', content: `Geographical Checklist | ${import.meta.env.VITE_BASE_TITLE}` },
@@ -37,7 +37,7 @@ export const Route = createFileRoute('/xatu/geographical-checklist')({
       },
       {
         name: 'twitter:image',
-        content: '/images/xatu/geographical-checklist.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/xatu/geographical-checklist.png`,
       },
     ],
   }),

--- a/src/routes/xatu/locally-built-blocks.tsx
+++ b/src/routes/xatu/locally-built-blocks.tsx
@@ -24,7 +24,7 @@ export const Route = createFileRoute('/xatu/locally-built-blocks')({
       },
       {
         property: 'og:image',
-        content: '/images/xatu/locally-built-blocks.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/xatu/locally-built-blocks.png`,
       },
       { name: 'twitter:url', content: `${import.meta.env.VITE_BASE_URL}/xatu/locally-built-blocks` },
       { name: 'twitter:title', content: `Locally Built Blocks | ${import.meta.env.VITE_BASE_TITLE}` },
@@ -34,7 +34,7 @@ export const Route = createFileRoute('/xatu/locally-built-blocks')({
       },
       {
         name: 'twitter:image',
-        content: '/images/xatu/locally-built-blocks.png',
+        content: `${import.meta.env.VITE_BASE_URL}/images/xatu/locally-built-blocks.png`,
       },
     ],
   }),


### PR DESCRIPTION
…er:image meta tags

Updated all route files to use full canonical URLs instead of relative paths for OpenGraph and Twitter Card image meta tags. This ensures proper image display when pages are shared on social media platforms.

Changes:
- Updated 18 route files across /ethereum, /xatu, /experiments sections
- All og:image and twitter:image tags now use VITE_BASE_URL environment variable
- Maintains consistency with existing URL meta tags (og:url, twitter:url)
- Build verified - head.json correctly generates full canonical URLs