### PR TITLE
fix: add random chunk hashing to prevent cascade invalidation errors

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -61,7 +61,12 @@ export default defineConfig({
           const randomHash = Math.random().toString(36).substring(2, 10);
           return `assets/[name]-${randomHash}.js`;
         },
-        assetFileNames: () => {
+        assetFileNames: assetInfo => {
+          // Keep fonts stable for caching (they never change)
+          if (assetInfo.name?.match(/\.(woff2?|ttf|eot|otf)$/)) {
+            return 'assets/[name]-[hash].[ext]';
+          }
+          // Random hash for everything else
           const randomHash = Math.random().toString(36).substring(2, 10);
           return `assets/[name]-${randomHash}.[ext]`;
         },


### PR DESCRIPTION
Generate random hashes for all chunks on each build to completely bust browser cache and prevent "Failed to fetch dynamically imported module" errors caused by Vite's chunk cascade invalidation issue.

When unchanged chunks import from changed chunks, their import statements change, causing their content hashes to change even though the actual code is identical. This creates a cascade where users with cached chunks try to import dependencies that no longer exist.

By using random hashes instead of content hashes, every deployment gets completely fresh chunk names, eliminating the possibility of cached chunks referencing non-existent dependencies.

Fixes vitejs/vite#6773