### PR TITLE
feat: add skeleton loaders for epochs, entities, and slot detail pages

### DIFF
--- a/src/components/Layout/LoadingContainer/LoadingContainer.tsx
+++ b/src/components/Layout/LoadingContainer/LoadingContainer.tsx
@@ -7,7 +7,7 @@ export function LoadingContainer({ className, shimmer = true }: LoadingContainer
     return (
       <div
         className={clsx(
-          'animate-shimmer bg-linear-to-r from-border via-surface to-border bg-[length:200%_100%] dark:from-border dark:via-surface dark:to-border',
+          'animate-shimmer bg-linear-to-r from-border/30 via-surface/50 to-border/30 bg-[length:200%_100%] dark:from-border/30 dark:via-surface/50 dark:to-border/30',
           className
         )}
         aria-hidden="true"
@@ -15,5 +15,5 @@ export function LoadingContainer({ className, shimmer = true }: LoadingContainer
     );
   }
 
-  return <div className={clsx('animate-pulse bg-border dark:bg-border', className)} aria-hidden="true" />;
+  return <div className={clsx('animate-pulse bg-border/30 dark:bg-border/30', className)} aria-hidden="true" />;
 }

--- a/src/pages/ethereum/entities/IndexPage.tsx
+++ b/src/pages/ethereum/entities/IndexPage.tsx
@@ -5,12 +5,12 @@ import { Alert } from '@/components/Feedback/Alert';
 import { Input } from '@/components/Forms/Input';
 import { Container } from '@/components/Layout/Container';
 import { Header } from '@/components/Layout/Header';
-import { LoadingContainer } from '@/components/Layout/LoadingContainer';
 import { Table } from '@/components/Lists/Table';
 import { useBeaconClock } from '@/hooks/useBeaconClock';
 import { formatEpoch } from '@/utils';
 
 import { useEntitiesData } from './hooks';
+import { EntitiesSkeleton } from './components/EntitiesSkeleton';
 
 /**
  * Entities list page - displays Ethereum validator entities
@@ -87,7 +87,7 @@ export function IndexPage(): React.JSX.Element {
           title="Entities"
           description="Track validator entities and their performance on the Ethereum beacon chain"
         />
-        <LoadingContainer className="h-96" />
+        <EntitiesSkeleton />
       </Container>
     );
   }

--- a/src/pages/ethereum/entities/components/EntitiesSkeleton/EntitiesSkeleton.tsx
+++ b/src/pages/ethereum/entities/components/EntitiesSkeleton/EntitiesSkeleton.tsx
@@ -1,0 +1,51 @@
+import type { JSX } from 'react';
+import { LoadingContainer } from '@/components/Layout/LoadingContainer';
+import { Table } from '@/components/Lists/Table';
+
+/**
+ * Loading skeleton for the Entities page
+ * Matches the layout of the entities table with search input
+ */
+export function EntitiesSkeleton(): JSX.Element {
+  // Create skeleton data for 20 rows
+  const skeletonData = Array.from({ length: 20 }, (_, i) => ({ id: i }));
+
+  return (
+    <>
+      {/* Search Input Skeleton */}
+      <div className="mt-6">
+        <LoadingContainer className="h-10 w-full rounded-md" />
+        <div className="mt-2 flex items-center justify-between">
+          <LoadingContainer className="h-4 w-48 rounded-sm" />
+          <LoadingContainer className="h-4 w-40 rounded-sm" />
+        </div>
+      </div>
+
+      {/* Table Section Skeleton */}
+      <div className="mt-6">
+        <Table
+          variant="nested"
+          data={skeletonData}
+          columns={[
+            {
+              header: 'Entity Name',
+              accessor: () => <LoadingContainer className="h-5 w-32 rounded-sm" />,
+            },
+            {
+              header: 'Status',
+              accessor: () => <LoadingContainer className="h-5 w-20 rounded-sm" />,
+            },
+            {
+              header: 'Validators',
+              accessor: () => <LoadingContainer className="h-5 w-16 rounded-sm" />,
+            },
+            {
+              header: 'Online Rate',
+              accessor: () => <LoadingContainer className="h-5 w-20 rounded-sm" />,
+            },
+          ]}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/pages/ethereum/entities/components/EntitiesSkeleton/index.ts
+++ b/src/pages/ethereum/entities/components/EntitiesSkeleton/index.ts
@@ -1,0 +1,1 @@
+export { EntitiesSkeleton } from './EntitiesSkeleton';

--- a/src/pages/ethereum/epochs/DetailPage.tsx
+++ b/src/pages/ethereum/epochs/DetailPage.tsx
@@ -17,7 +17,6 @@ import { TopEntitiesChart } from '@/components/Ethereum/TopEntitiesChart';
 import { TransactionCountChart } from '@/components/Ethereum/TransactionCountChart';
 import { Container } from '@/components/Layout/Container';
 import { Header } from '@/components/Layout/Header';
-import { LoadingContainer } from '@/components/Layout/LoadingContainer';
 import { Button } from '@/components/Elements/Button';
 import { Tab } from '@/components/Navigation/Tab';
 import { ScrollableTabs } from '@/components/Navigation/ScrollableTabs';
@@ -28,7 +27,7 @@ import { useNetworkChangeRedirect } from '@/hooks/useNetworkChangeRedirect';
 import { useTabState } from '@/hooks/useTabState';
 import { Route } from '@/routes/ethereum/epochs/$epoch';
 
-import { EpochHeader, EpochSlotsTable } from './components';
+import { EpochHeader, EpochSlotsTable, EpochDetailSkeleton } from './components';
 import { useEpochDetailData } from './hooks';
 
 /**
@@ -135,8 +134,7 @@ export function DetailPage(): React.JSX.Element {
   if (isLoading) {
     return (
       <Container>
-        <Header title={`Epoch ${formatEpoch(epoch)}`} description="Loading epoch data..." />
-        <LoadingContainer className="h-96" />
+        <EpochDetailSkeleton epoch={epoch} />
       </Container>
     );
   }

--- a/src/pages/ethereum/epochs/IndexPage.tsx
+++ b/src/pages/ethereum/epochs/IndexPage.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from '@tanstack/react-router';
 import { Alert } from '@/components/Feedback/Alert';
 import { Container } from '@/components/Layout/Container';
 import { Header } from '@/components/Layout/Header';
-import { LoadingContainer } from '@/components/Layout/LoadingContainer';
 import { Table } from '@/components/Lists/Table';
 
 import { Epoch } from '@/components/Ethereum/Epoch';
@@ -11,6 +10,7 @@ import { TopEntitiesChart } from '@/components/Ethereum/TopEntitiesChart';
 import { Timestamp } from '@/components/DataDisplay/Timestamp';
 
 import { useEpochsData } from './hooks';
+import { EpochsSkeleton } from './components/EpochsSkeleton';
 
 /**
  * Epochs list page - displays the last 5 recent epochs
@@ -55,7 +55,7 @@ export function IndexPage(): React.JSX.Element {
     return (
       <Container>
         <Header title="Epochs" description="Explore Ethereum beacon chain epochs and their attestation data" />
-        <LoadingContainer className="h-96" />
+        <EpochsSkeleton />
       </Container>
     );
   }

--- a/src/pages/ethereum/epochs/components/EpochDetailSkeleton/EpochDetailSkeleton.tsx
+++ b/src/pages/ethereum/epochs/components/EpochDetailSkeleton/EpochDetailSkeleton.tsx
@@ -1,0 +1,151 @@
+import type { JSX } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { LoadingContainer } from '@/components/Layout/LoadingContainer';
+import { Table } from '@/components/Lists/Table';
+import { Button } from '@/components/Elements/Button';
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+import { TabGroup, TabPanel, TabPanels } from '@headlessui/react';
+import { Tab } from '@/components/Navigation/Tab';
+import { ScrollableTabs } from '@/components/Navigation/ScrollableTabs';
+import { formatEpoch } from '@/utils';
+
+export interface EpochDetailSkeletonProps {
+  /** The epoch number being loaded */
+  epoch: number;
+}
+
+/**
+ * Loading skeleton for the Epoch Detail page
+ * Matches the layout of the epoch detail view with header, tabs, and slots table
+ */
+export function EpochDetailSkeleton({ epoch }: EpochDetailSkeletonProps): JSX.Element {
+  const navigate = useNavigate();
+  // Create skeleton data for 32 slot rows
+  const skeletonSlots = Array.from({ length: 32 }, (_, i) => ({ id: i }));
+
+  return (
+    <>
+      {/* Navigation Controls */}
+      <div className="mb-6 flex items-center justify-between gap-4">
+        <Button
+          variant="secondary"
+          size="sm"
+          rounded="sm"
+          leadingIcon={<ChevronLeftIcon />}
+          disabled={epoch === 0}
+          onClick={() => navigate({ to: '/ethereum/epochs/$epoch', params: { epoch: String(epoch - 1) } })}
+          aria-label="Previous epoch"
+        >
+          Previous
+        </Button>
+        <div className="flex-1" />
+        <Button
+          variant="secondary"
+          size="sm"
+          rounded="sm"
+          trailingIcon={<ChevronRightIcon />}
+          onClick={() => navigate({ to: '/ethereum/epochs/$epoch', params: { epoch: String(epoch + 1) } })}
+          aria-label="Next epoch"
+        >
+          Next
+        </Button>
+      </div>
+
+      {/* Epoch Header Skeleton */}
+      <div className="overflow-hidden rounded-sm border border-border bg-surface">
+        {/* Header section */}
+        <div className="border-b border-border bg-background px-6 py-4">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-6">
+              {/* EpochArt skeleton */}
+              <div className="shrink-0">
+                <LoadingContainer className="size-20 rounded-sm" />
+              </div>
+
+              <div>
+                <h1 className="text-3xl font-bold tracking-tight text-foreground">Epoch {formatEpoch(epoch)}</h1>
+                <div className="mt-1">
+                  <LoadingContainer className="h-5 w-56 rounded-sm" />
+                </div>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <LoadingContainer className="size-8 rounded-sm" />
+              <LoadingContainer className="size-8 rounded-sm" />
+              <LoadingContainer className="size-8 rounded-sm" />
+            </div>
+          </div>
+        </div>
+
+        {/* Stats Grid */}
+        <div className="grid grid-cols-2 gap-4 p-6 sm:grid-cols-4">
+          {['Blocks', 'P95 Block Arrival', 'Attestation Participation', 'Missed Attestations'].map(label => (
+            <div key={label} className="rounded-sm border border-border bg-background p-4">
+              <dt className="text-xs font-medium text-muted">{label}</dt>
+              <dd className="mt-1">
+                <LoadingContainer className="h-6 w-16 rounded-sm" />
+              </dd>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Tabbed Content Skeleton */}
+      <div className="mt-8">
+        <TabGroup selectedIndex={0}>
+          <ScrollableTabs>
+            <Tab>Slots</Tab>
+            <Tab>Blocks</Tab>
+            <Tab>Validators</Tab>
+            <Tab>MEV</Tab>
+          </ScrollableTabs>
+
+          <TabPanels className="mt-6">
+            {/* Slots Tab Skeleton */}
+            <TabPanel>
+              <Table
+                variant="nested"
+                data={skeletonSlots}
+                columns={[
+                  {
+                    header: 'Slot',
+                    accessor: () => <LoadingContainer className="h-5 w-20 rounded-sm" />,
+                  },
+                  {
+                    header: 'Timestamp',
+                    accessor: () => <LoadingContainer className="h-5 w-24 rounded-sm" />,
+                  },
+                  {
+                    header: 'Proposer Index',
+                    accessor: () => <LoadingContainer className="h-5 w-16 rounded-sm" />,
+                  },
+                  {
+                    header: 'Proposer Entity',
+                    accessor: () => <LoadingContainer className="h-5 w-24 rounded-sm" />,
+                  },
+                  {
+                    header: 'Status',
+                    accessor: () => <LoadingContainer className="h-5 w-20 rounded-sm" />,
+                  },
+                  {
+                    header: 'Blobs',
+                    accessor: () => <LoadingContainer className="h-5 w-8 rounded-sm" />,
+                  },
+                  {
+                    header: 'Attestations',
+                    accessor: () => <LoadingContainer className="h-5 w-24 rounded-sm" />,
+                  },
+                  {
+                    header: 'Vote %',
+                    accessor: () => <LoadingContainer className="h-5 w-16 rounded-sm" />,
+                  },
+                ]}
+              />
+            </TabPanel>
+          </TabPanels>
+        </TabGroup>
+      </div>
+    </>
+  );
+}

--- a/src/pages/ethereum/epochs/components/EpochDetailSkeleton/index.ts
+++ b/src/pages/ethereum/epochs/components/EpochDetailSkeleton/index.ts
@@ -1,0 +1,1 @@
+export { EpochDetailSkeleton } from './EpochDetailSkeleton';

--- a/src/pages/ethereum/epochs/components/EpochsSkeleton/EpochsSkeleton.tsx
+++ b/src/pages/ethereum/epochs/components/EpochsSkeleton/EpochsSkeleton.tsx
@@ -1,0 +1,88 @@
+import type { JSX } from 'react';
+import { LoadingContainer } from '@/components/Layout/LoadingContainer';
+import { Table } from '@/components/Lists/Table';
+
+/**
+ * Loading skeleton for the Epochs page
+ * Matches the layout of the epochs table and metrics chart
+ */
+export function EpochsSkeleton(): JSX.Element {
+  // Create skeleton data for 10 rows
+  const skeletonData = Array.from({ length: 10 }, (_, i) => ({ id: i }));
+
+  return (
+    <>
+      {/* Table Section Skeleton */}
+      <div className="mt-6">
+        <Table
+          variant="nested"
+          data={skeletonData}
+          columns={[
+            {
+              header: 'Epoch',
+              accessor: () => <LoadingContainer className="h-5 w-20 rounded-sm" />,
+            },
+            {
+              header: 'Start Time',
+              accessor: () => <LoadingContainer className="h-5 w-36 rounded-sm" />,
+            },
+            {
+              header: 'Relative Time',
+              accessor: () => <LoadingContainer className="h-5 w-24 rounded-sm" />,
+            },
+            {
+              header: 'Blocks',
+              accessor: () => <LoadingContainer className="h-5 w-16 rounded-sm" />,
+            },
+            {
+              header: 'Missed Blocks',
+              accessor: () => <LoadingContainer className="h-5 w-8 rounded-sm" />,
+            },
+            {
+              header: 'Participation %',
+              accessor: () => <LoadingContainer className="h-5 w-20 rounded-sm" />,
+            },
+          ]}
+        />
+
+        {/* Helper text skeleton */}
+        <div className="mt-4">
+          <LoadingContainer className="h-4 w-96 rounded-sm" />
+        </div>
+      </div>
+
+      {/* Metrics Section Skeleton */}
+      <div id="metrics" className="mt-8">
+        {/* Section header */}
+        <div className="mb-4">
+          <LoadingContainer className="h-7 w-24 rounded-sm" />
+        </div>
+
+        {/* Chart card */}
+        <div className="rounded-lg border border-border bg-surface p-6">
+          {/* Chart header */}
+          <div className="mb-4 flex items-start justify-between">
+            <div className="space-y-2">
+              <LoadingContainer className="h-6 w-40 rounded-sm" />
+              <LoadingContainer className="h-4 w-56 rounded-sm" />
+            </div>
+            <div className="flex gap-2">
+              <LoadingContainer className="size-8 rounded-sm" />
+              <LoadingContainer className="size-8 rounded-sm" />
+            </div>
+          </div>
+
+          {/* Legend */}
+          <div className="mb-4 flex flex-wrap gap-2">
+            {[...Array(12)].map((_, i) => (
+              <LoadingContainer key={i} className="h-6 w-24 rounded-full" />
+            ))}
+          </div>
+
+          {/* Chart area */}
+          <LoadingContainer className="h-[400px] rounded-sm" />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/pages/ethereum/epochs/components/EpochsSkeleton/index.ts
+++ b/src/pages/ethereum/epochs/components/EpochsSkeleton/index.ts
@@ -1,0 +1,1 @@
+export { EpochsSkeleton } from './EpochsSkeleton';

--- a/src/pages/ethereum/epochs/components/index.ts
+++ b/src/pages/ethereum/epochs/components/index.ts
@@ -1,2 +1,4 @@
 export { EpochHeader } from './EpochHeader';
 export { EpochSlotsTable } from './EpochSlotsTable';
+export { EpochDetailSkeleton } from './EpochDetailSkeleton';
+export { EpochsSkeleton } from './EpochsSkeleton';

--- a/src/pages/ethereum/slots/DetailPage.tsx
+++ b/src/pages/ethereum/slots/DetailPage.tsx
@@ -5,7 +5,6 @@ import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import { Container } from '@/components/Layout/Container';
 import { Header } from '@/components/Layout/Header';
 import { Alert } from '@/components/Feedback/Alert';
-import { LoadingContainer } from '@/components/Layout/LoadingContainer';
 import { Card } from '@/components/Layout/Card';
 import { Tab } from '@/components/Navigation/Tab';
 import { ScrollableTabs } from '@/components/Navigation/ScrollableTabs';
@@ -35,6 +34,7 @@ import { CopyToClipboard } from '@/components/Elements/CopyToClipboard';
 import { ForkLabel } from '@/components/Ethereum/ForkLabel';
 import { formatGasToMillions, ATTESTATION_DEADLINE_MS } from '@/utils';
 import type { ForkVersion } from '@/utils/beacon';
+import { SlotDetailSkeleton } from './components/SlotDetailSkeleton';
 
 /**
  * Detail page for a specific slot.
@@ -120,18 +120,7 @@ export function DetailPage(): JSX.Element {
   if (isLoading) {
     return (
       <Container>
-        <Header title={`Slot ${slot}`} description={`Epoch ${formatEpoch(epoch)}`} />
-        <div className="space-y-6">
-          {/* Basic info skeleton */}
-          <LoadingContainer className="h-64 rounded-sm" />
-
-          {/* Chart grid skeleton */}
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-3">
-            <LoadingContainer className="col-span-1 h-96 rounded-sm lg:col-span-2" />
-            <LoadingContainer className="col-span-1 h-96 rounded-sm" />
-            <LoadingContainer className="col-span-1 h-96 rounded-sm lg:col-span-2" />
-          </div>
-        </div>
+        <SlotDetailSkeleton slot={slot} epoch={epoch} />
       </Container>
     );
   }

--- a/src/pages/ethereum/slots/components/SlotDetailSkeleton/SlotDetailSkeleton.tsx
+++ b/src/pages/ethereum/slots/components/SlotDetailSkeleton/SlotDetailSkeleton.tsx
@@ -1,0 +1,262 @@
+import type { JSX } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { LoadingContainer } from '@/components/Layout/LoadingContainer';
+import { Button } from '@/components/Elements/Button';
+import { Card } from '@/components/Layout/Card';
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+import { TabGroup, TabPanel, TabPanels } from '@headlessui/react';
+import { Tab } from '@/components/Navigation/Tab';
+import { ScrollableTabs } from '@/components/Navigation/ScrollableTabs';
+import { formatSlot } from '@/utils';
+
+export interface SlotDetailSkeletonProps {
+  /** The slot number being loaded */
+  slot: number;
+  /** The epoch number for this slot */
+  epoch: number;
+}
+
+/**
+ * Loading skeleton for the Slot Detail page
+ * Matches the layout of the slot detail view with navigation, slot info card, tabs, and overview cards
+ */
+export function SlotDetailSkeleton({ slot, epoch }: SlotDetailSkeletonProps): JSX.Element {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      {/* Navigation Controls */}
+      <div className="mb-6 flex items-center justify-between gap-4">
+        <Button
+          variant="secondary"
+          size="sm"
+          rounded="sm"
+          leadingIcon={<ChevronLeftIcon />}
+          disabled={slot === 0}
+          onClick={() => navigate({ to: '/ethereum/slots/$slot', params: { slot: String(slot - 1) } })}
+          aria-label="Previous slot"
+        >
+          Previous
+        </Button>
+        <div className="flex-1" />
+        <Button
+          variant="secondary"
+          size="sm"
+          rounded="sm"
+          trailingIcon={<ChevronRightIcon />}
+          onClick={() => navigate({ to: '/ethereum/slots/$slot', params: { slot: String(slot + 1) } })}
+          aria-label="Next slot"
+        >
+          Next
+        </Button>
+      </div>
+
+      {/* Slot Basic Info Card Skeleton */}
+      <div className="overflow-hidden rounded-sm border border-border bg-surface">
+        {/* Header section */}
+        <div className="border-b border-border bg-background px-6 py-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg/7 font-semibold text-foreground">Slot Information</h2>
+            <div className="flex items-center gap-2">
+              <LoadingContainer className="size-5 rounded-sm" />
+              <LoadingContainer className="size-5 rounded-sm" />
+              <LoadingContainer className="size-5 rounded-sm" />
+              <LoadingContainer className="size-5 rounded-sm" />
+            </div>
+          </div>
+        </div>
+
+        {/* Card content */}
+        <div className="p-6">
+          <div className="flex flex-col gap-6 lg:flex-row">
+            <div className="flex-1 space-y-6">
+              {/* Status Section */}
+              <div className="flex flex-wrap items-center gap-2">
+                <LoadingContainer className="h-6 w-24 rounded-sm" />
+                <LoadingContainer className="h-6 w-20 rounded-sm" />
+              </div>
+
+              {/* Basic Information Section */}
+              <div>
+                <h3 className="mb-3 text-sm font-semibold text-foreground">Basic Information</h3>
+                <div className="grid grid-cols-2 gap-x-6 gap-y-4 sm:grid-cols-3 lg:grid-cols-4">
+                  {/* Slot Number */}
+                  <div>
+                    <dt className="text-xs font-medium text-muted">Slot</dt>
+                    <dd className="mt-1 text-base/7 font-semibold text-foreground">{formatSlot(slot)}</dd>
+                  </div>
+
+                  {/* Epoch */}
+                  <div>
+                    <dt className="text-xs font-medium text-muted">Epoch</dt>
+                    <dd className="mt-1 text-base/7 font-semibold text-foreground">{epoch}</dd>
+                  </div>
+
+                  {/* Fork */}
+                  <div>
+                    <dt className="text-xs font-medium text-muted">Fork</dt>
+                    <dd className="mt-1">
+                      <LoadingContainer className="h-6 w-20 rounded-sm" />
+                    </dd>
+                  </div>
+
+                  {/* Execution Block Number */}
+                  <div>
+                    <dt className="text-xs font-medium text-muted">Execution Block</dt>
+                    <dd className="mt-1">
+                      <LoadingContainer className="h-6 w-20 rounded-sm" />
+                    </dd>
+                  </div>
+
+                  {/* Blob Count */}
+                  <div>
+                    <dt className="text-xs font-medium text-muted">Blobs</dt>
+                    <dd className="mt-1">
+                      <LoadingContainer className="h-6 w-8 rounded-sm" />
+                    </dd>
+                  </div>
+
+                  {/* Slot Timestamp */}
+                  <div className="col-span-2">
+                    <dt className="text-xs font-medium text-muted">Slot Time</dt>
+                    <dd className="mt-1">
+                      <LoadingContainer className="h-5 w-48 rounded-sm" />
+                    </dd>
+                  </div>
+
+                  {/* Relative Time */}
+                  <div className="col-span-2 sm:col-span-1">
+                    <dt className="text-xs font-medium text-muted">Age</dt>
+                    <dd className="mt-1">
+                      <LoadingContainer className="h-5 w-20 rounded-sm" />
+                    </dd>
+                  </div>
+
+                  {/* Epoch Timestamp */}
+                  <div className="col-span-2">
+                    <dt className="text-xs font-medium text-muted">Epoch Start</dt>
+                    <dd className="mt-1">
+                      <LoadingContainer className="h-5 w-48 rounded-sm" />
+                    </dd>
+                  </div>
+                </div>
+              </div>
+
+              {/* Block Details Section */}
+              <div>
+                <h3 className="mb-3 text-sm font-semibold text-foreground">Block Details</h3>
+                <div className="grid grid-cols-2 gap-x-6 gap-y-4 sm:grid-cols-3 lg:grid-cols-4">
+                  {/* Proposer Entity */}
+                  <div className="col-span-2">
+                    <dt className="text-xs font-medium text-muted">Proposer</dt>
+                    <dd className="mt-1">
+                      <LoadingContainer className="h-5 w-32 rounded-sm" />
+                    </dd>
+                  </div>
+
+                  {/* MEV Value */}
+                  <div className="col-span-2">
+                    <dt className="text-xs font-medium text-muted">MEV Value</dt>
+                    <dd className="mt-1">
+                      <LoadingContainer className="h-6 w-24 rounded-sm" />
+                    </dd>
+                  </div>
+
+                  {/* Block Root */}
+                  <div className="col-span-2 sm:col-span-3 lg:col-span-4">
+                    <dt className="text-xs font-medium text-muted">Block Root</dt>
+                    <dd className="mt-1">
+                      <LoadingContainer className="h-4 w-48 rounded-sm" />
+                    </dd>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="flex items-center justify-center lg:items-start">
+              <LoadingContainer className="size-[180px] rounded-sm" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Tabbed Content Skeleton */}
+      <div className="mt-8">
+        <TabGroup selectedIndex={0}>
+          <ScrollableTabs>
+            <Tab>Overview</Tab>
+            <Tab>Block</Tab>
+            <Tab>Attestations</Tab>
+            <Tab>Propagation</Tab>
+            <Tab>Execution</Tab>
+            <Tab>MEV</Tab>
+          </ScrollableTabs>
+
+          <TabPanels className="mt-6">
+            {/* Overview Tab Skeleton */}
+            <TabPanel>
+              <div className="space-y-6">
+                {/* Performance Metrics Card */}
+                <Card>
+                  <div className="mb-4">
+                    <h3 className="text-lg font-semibold text-foreground">Performance Metrics</h3>
+                    <p className="text-sm text-muted">Block timing and attestation statistics</p>
+                  </div>
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                    {['Block First Seen At', 'Gas Used', 'Participation', 'Block Votes'].map(label => (
+                      <div key={label}>
+                        <dt className="text-xs font-medium text-muted">{label}</dt>
+                        <dd className="mt-2 flex items-center gap-3">
+                          <LoadingContainer className="size-12 rounded-full" />
+                          <div>
+                            <LoadingContainer className="h-5 w-16 rounded-sm" />
+                          </div>
+                        </dd>
+                      </div>
+                    ))}
+                  </div>
+                </Card>
+
+                {/* Network Propagation Card */}
+                <Card>
+                  <div className="mb-4">
+                    <h3 className="text-lg font-semibold text-foreground">Network Propagation</h3>
+                    <p className="text-sm text-muted">Nodes that received block data</p>
+                  </div>
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                    <div>
+                      <dt className="text-xs font-medium text-muted">Block Nodes</dt>
+                      <dd className="mt-1">
+                        <LoadingContainer className="h-6 w-12 rounded-sm" />
+                      </dd>
+                    </div>
+                  </div>
+                </Card>
+
+                {/* MEV Activity Card */}
+                <Card>
+                  <div className="mb-4">
+                    <h3 className="text-lg font-semibold text-foreground">MEV Activity</h3>
+                    <p className="text-sm text-muted">Block builder and relay participation</p>
+                  </div>
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                    {['Relays', 'Builders'].map(label => (
+                      <div key={label}>
+                        <dt className="text-xs font-medium text-muted">{label}</dt>
+                        <dd className="mt-2">
+                          <LoadingContainer className="h-6 w-12 rounded-sm" />
+                          <div className="mt-1">
+                            <LoadingContainer className="h-4 w-24 rounded-sm" />
+                          </div>
+                        </dd>
+                      </div>
+                    ))}
+                  </div>
+                </Card>
+              </div>
+            </TabPanel>
+          </TabPanels>
+        </TabGroup>
+      </div>
+    </>
+  );
+}

--- a/src/pages/ethereum/slots/components/SlotDetailSkeleton/index.ts
+++ b/src/pages/ethereum/slots/components/SlotDetailSkeleton/index.ts
@@ -1,0 +1,1 @@
+export { SlotDetailSkeleton } from './SlotDetailSkeleton';


### PR DESCRIPTION
- Soften LoadingContainer appearance with 30% border and 50% surface opacity
- Add EpochsSkeleton for epochs list page with table and metrics chart
- Add EntitiesSkeleton for entities list page with search and table
- Add EpochDetailSkeleton for epoch detail page with navigation, stats, and tabs
- Add SlotDetailSkeleton for slot detail page with card-based layout
- All skeletons match exact structure and styling of loaded views
- Navigation buttons remain functional during loading states
- Display actual slot/epoch numbers in skeletons for better context