### PR TITLE
feat(forks): display fork local time in upcoming fork section

### DIFF
--- a/src/pages/ethereum/forks/components/ForksHeader/ForksHeader.tsx
+++ b/src/pages/ethereum/forks/components/ForksHeader/ForksHeader.tsx
@@ -1,5 +1,7 @@
 import { Card } from '@/components/Layout/Card';
+import { Timestamp } from '@/components/DataDisplay/Timestamp';
 import type { ForkInfo } from '@/utils/forks';
+import { epochToTimestamp } from '@/utils/beacon';
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/20/solid';
 import { useNetwork } from '@/hooks/useNetwork';
 import { useState, useEffect } from 'react';
@@ -227,6 +229,12 @@ export function ForksHeader({ activeFork, nextFork, allForks }: ForksHeaderProps
           <div className="mb-2 text-xs font-medium tracking-wider text-accent uppercase">Next Upgrade</div>
           <h2 className="text-3xl font-bold text-foreground">{nextFork.displayName}</h2>
           <p className="mt-3 text-sm text-muted">{nextFork.description}</p>
+          {currentNetwork?.genesis_time && (
+            <div className="mt-4 text-base font-medium text-foreground">
+              Local Time:{' '}
+              <Timestamp timestamp={epochToTimestamp(nextFork.epoch, currentNetwork.genesis_time)} format="long" />
+            </div>
+          )}
         </div>
 
         {/* Countdown display */}


### PR DESCRIPTION
## Summary

Displays the local time when an upcoming fork is scheduled to go live. Uses the existing `Timestamp` component for consistency and adds a clickable timestamp that shows additional formats (UTC, Unix, beacon slot/epoch).

## Changes

- Import `Timestamp` component from DataDisplay
- Add local time display with "Local Time:" prefix in the upcoming fork info section
- Styling: text-base font-medium text-foreground with mt-4 margin for prominence

## Test Plan

- View the ethereum/forks page with an upcoming fork
- Verify the local time displays in the format: "Local Time: Wednesday, January 15, 2025 at 12:00 PM PST"
- Click on the timestamp to verify the modal shows additional time formats