### PR TITLE
feat(__root.tsx): add embed mode via ?embed=true search param

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import {
   HeadContent,
   Link,
   useRouter,
+  useSearch,
   retainSearchParams,
 } from '@tanstack/react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -34,9 +35,10 @@ interface MyRouterContext {
   };
 }
 
-// Define search params schema for network selection
+// Define search params schema for network selection and embed mode
 const rootSearchSchema = z.object({
   network: z.string().optional(),
+  embed: z.boolean().optional(),
 });
 
 export type RootSearch = z.infer<typeof rootSearchSchema>;
@@ -119,6 +121,7 @@ function RootComponent(): JSX.Element {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [isAppleWatch, setIsAppleWatch] = useState(false);
   const router = useRouter();
+  const { embed } = useSearch({ from: '__root__' });
 
   // Detect Apple Watch using multiple heuristics
   // Apple Watch reports as iPhone but has distinctive screen dimensions
@@ -184,6 +187,32 @@ function RootComponent(): JSX.Element {
               🤡
             </span>
           </div>
+        </ThemeProvider>
+      </QueryClientProvider>
+    );
+  }
+
+  // Embed mode: minimal layout without sidebar, header, or breadcrumb
+  if (embed) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <NotificationProvider>
+            <TimezoneProvider>
+              <ConfigGate>
+                <NetworkProvider>
+                  <SharedCrosshairsProvider>
+                    <HeadContent />
+                    <main className="min-h-dvh bg-background">
+                      <FeatureGate>
+                        <Outlet />
+                      </FeatureGate>
+                    </main>
+                  </SharedCrosshairsProvider>
+                </NetworkProvider>
+              </ConfigGate>
+            </TimezoneProvider>
+          </NotificationProvider>
         </ThemeProvider>
       </QueryClientProvider>
     );


### PR DESCRIPTION
Embed mode hides sidebar, header and breadcrumb to allow the app to be embedded in third-party pages with minimal UI.

<img width="1604" height="946" alt="Screenshot 2025-12-02 at 10 56 50" src="https://github.com/user-attachments/assets/7399f622-e57e-43b8-a641-6c9af335a6c7" />
