### PR TITLE
Add hover panel for map nodes with details

### DIFF
--- a/src/components/Charts/Map2D/Map2D.types.ts
+++ b/src/components/Charts/Map2D/Map2D.types.ts
@@ -4,10 +4,20 @@ export interface RouteData {
   name?: string;
 }
 
+/** Node data for hover display */
+export interface PointNodeData {
+  nodeId: string; // Unique node identifier
+  username?: string; // Node operator username
+  timing: number; // Block timing in ms from slot start
+  client?: string; // Client implementation name
+  country?: string; // Country name for geo hover aggregation
+}
+
 export interface PointData {
   name?: string;
   coords: [number, number]; // [longitude, latitude]
   value?: number; // Optional value for sizing the point
+  nodes?: PointNodeData[]; // All nodes at this location for tooltip display
 }
 
 export interface Map2DChartProps {

--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -144,7 +144,7 @@ function SidebarFooter({
             <XIcon className="size-4" />
           </a>
         </div>
-        {window.__VERSION__ && <span className="text-[10px] text-muted/60">v{window.__VERSION__.version}</span>}
+        {window.__VERSION__ && <span className="text-[10px] text-muted/60">{window.__VERSION__.version}</span>}
         <button
           type="button"
           onClick={onToggleCollapse}
@@ -366,7 +366,7 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, collapsed, setCollapsed }
                       <XIcon className="size-5" />
                     </a>
                   </div>
-                  {window.__VERSION__ && <span className="text-xs text-muted/60">v{window.__VERSION__.version}</span>}
+                  {window.__VERSION__ && <span className="text-xs text-muted/60">{window.__VERSION__.version}</span>}
                 </div>
               </div>
             </div>

--- a/src/pages/ethereum/live/hooks/useMapData/useMapData.ts
+++ b/src/pages/ethereum/live/hooks/useMapData/useMapData.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import type { FctBlockFirstSeenByNode } from '@/api/types.gen';
-import type { PointData } from '@/components/Charts/Map/Map.types';
+import type { PointData, PointNodeData } from '@/components/Charts/Map2D/Map2D.types';
 
 export interface MapPointWithTiming extends PointData {
   earliestSeenTime: number; // Earliest seen_slot_start_diff for this city group
@@ -36,11 +36,23 @@ export function useMapData(nodes: FctBlockFirstSeenByNode[]): MapPointWithTiming
         const lon = node.meta_client_geo_longitude;
         const lat = node.meta_client_geo_latitude;
 
+        // Build node data for hover display, sorted by timing
+        const nodes: PointNodeData[] = cityNodes
+          .map(n => ({
+            nodeId: n.node_id ?? 'unknown',
+            username: n.username,
+            timing: n.seen_slot_start_diff ?? 0,
+            client: n.meta_consensus_implementation,
+            country: n.meta_client_geo_country,
+          }))
+          .sort((a, b) => a.timing - b.timing);
+
         return {
           name,
           coords: [lon ?? null, lat ?? null] as [number | null, number | null],
           value: cityNodes.length, // Number of nodes at this location
           earliestSeenTime: earliestSeenTime === Infinity ? 0 : earliestSeenTime,
+          nodes,
         };
       })
       .filter(point => {


### PR DESCRIPTION
## Summary
Added an enhanced hover panel for the map that displays detailed node information when hovering over cities or countries. Shows node ID, username, consensus client, and block timing in an easy-to-read table format at the top of the map.

## Features
- Fixed panel positioned at top center of map showing all nodes at hovered location
- Supports both city-level and country-level aggregation
- Displays node ID (with truncation), username, consensus client, and timing
- Removed "v" prefix from sidebar version display
- Replaced ECharts tooltip with custom React-based panel

## Screenshots
<img width="1679" height="1304" alt="Screenshot 2025-12-03 at 12 34 30 pm" src="https://github.com/user-attachments/assets/e04681b3-9a52-465e-a78e-8644898835ac" />