### PR TITLE
feat: add berlin cluster for EIP-7870 reference nodes

### DIFF
--- a/src/constants/eip7870.ts
+++ b/src/constants/eip7870.ts
@@ -76,6 +76,27 @@ export const CLUSTER_SPECS: ClusterSpec[] = [
       interface: 'NVMe',
     },
   },
+  {
+    name: 'berlin',
+    cpu: {
+      model: 'AMD Ryzen 7 5800U',
+      cores: 8,
+      threads: 16,
+      maxFrequency: '4.5 GHz',
+      passmarkSingle: '~3,000',
+      passmarkMulti: '~19k',
+    },
+    memory: {
+      total: '32 GB',
+      type: 'DDR4',
+      speed: '3200 MT/s',
+    },
+    storage: {
+      model: 'Samsung 970 EVO Plus',
+      capacity: '2 TB',
+      interface: 'NVMe',
+    },
+  },
 ];
 
 /**
@@ -84,6 +105,7 @@ export const CLUSTER_SPECS: ClusterSpec[] = [
 export const CLUSTER_COLORS: Record<string, string> = {
   utility: 'text-blue-500',
   sigma: 'text-emerald-500',
+  berlin: 'text-amber-500',
 };
 
 /**
@@ -105,10 +127,12 @@ export function extractClusterFromNodeName(nodeName: string): string | null {
     .replace(/^ethpandaops\/mainnet\//, '')
     .replace(/^ethpandaops\//, '')
     .replace(/^utility-mainnet-/, 'utility/')
-    .replace(/^sigma-mainnet-/, 'sigma/');
+    .replace(/^sigma-mainnet-/, 'sigma/')
+    .replace(/^berlin-/, 'berlin/');
 
   if (shortName.startsWith('utility/')) return 'utility';
   if (shortName.startsWith('sigma/')) return 'sigma';
+  if (shortName.startsWith('berlin/')) return 'berlin';
 
   return null;
 }

--- a/src/pages/ethereum/execution/payloads/components/PayloadsView/PayloadsView.tsx
+++ b/src/pages/ethereum/execution/payloads/components/PayloadsView/PayloadsView.tsx
@@ -263,7 +263,8 @@ export function PayloadsView({
             .replace(/^ethpandaops\/mainnet\//, '')
             .replace(/^ethpandaops\//, '')
             .replace(/^utility-mainnet-/, 'utility/')
-            .replace(/^sigma-mainnet-/, 'sigma/');
+            .replace(/^sigma-mainnet-/, 'sigma/')
+            .replace(/^berlin-/, 'berlin/');
           // Truncate long node names
           const displayName = shortName.length > 35 ? `${shortName.slice(0, 35)}...` : shortName;
           // Extract cluster for EIP-7870 reference nodes

--- a/src/pages/ethereum/execution/timings/components/ClientVersionBreakdown/ClientVersionBreakdown.tsx
+++ b/src/pages/ethereum/execution/timings/components/ClientVersionBreakdown/ClientVersionBreakdown.tsx
@@ -122,6 +122,7 @@ function shortenNodeName(nodeName?: string): string {
     .replace(/^ethpandaops\//, '')
     .replace(/^utility-mainnet-/, 'utility/')
     .replace(/^sigma-mainnet-/, 'sigma/')
+    .replace(/^berlin-/, 'berlin/')
     .replace(/^prysm-/, '');
 }
 


### PR DESCRIPTION
## Summary

Adds the new `berlin` cluster to the EIP-7870 reference-node spec data so its 8 nodes show up in the hardware banner, cluster-specs modal, and node-row badges alongside `utility` and `sigma`.

Hardware (pulled live from `devops@asrock-berlin-*` over tailscale):
- CPU: AMD Ryzen 7 5800U (8c / 16t, 4.5 GHz)
- Memory: 32 GB DDR4-3200
- Storage: Samsung 970 EVO Plus 2 TB NVMe (common case across the 8 nodes)

A bit underspecced relative to `utility` and `sigma` — expected.

Touches:
- `src/constants/eip7870.ts` — new `CLUSTER_SPECS` entry, color, and `/^berlin-/` prefix in `extractClusterFromNodeName`
- `PayloadsView.tsx` and `ClientVersionBreakdown.tsx` — the two local copies of the shorten-node-name replace chain