### PR TITLE
feat(slots): blobs panel card + gate blob downloads on finality

### DIFF
--- a/src/pages/ethereum/slots/DetailPage.tsx
+++ b/src/pages/ethereum/slots/DetailPage.tsx
@@ -22,7 +22,10 @@ import { useNetworkChangeRedirect } from '@/hooks/useNetworkChangeRedirect';
 import { useTabState } from '@/hooks/useTabState';
 import { useNetwork } from '@/hooks/useNetwork';
 import { Route } from '@/routes/ethereum/slots/$slot';
-import { dimBlockBlobSubmitterServiceListOptions } from '@/api/@tanstack/react-query.gen';
+import {
+  dimBlockBlobSubmitterServiceListOptions,
+  fctBlockBlobHeadServiceListOptions,
+} from '@/api/@tanstack/react-query.gen';
 import { useSlotDetailData } from './hooks/useSlotDetailData';
 import { useAllAttestationVotes } from './hooks/useAllAttestationVotes';
 import { SlotBasicInfoCard } from './components/SlotBasicInfoCard';
@@ -143,6 +146,18 @@ export function DetailPage(): JSX.Element {
     enabled: !!executionBlockNumber,
   });
   const blobSubmitters = blobSubmittersData?.dim_block_blob_submitter ?? [];
+
+  // Fetch the slot's blobs from the head table (real-time, one row per blob with
+  // its versioned hash + KZG commitment) — drives the blobs listing.
+  const { data: blobHeadData } = useQuery({
+    ...fctBlockBlobHeadServiceListOptions({
+      query: { slot_start_date_time_eq: slotTimestamp, page_size: 100 },
+    }),
+    enabled: !!currentNetwork && slotTimestamp > 0,
+  });
+  const blobDetails = (blobHeadData?.fct_block_blob_head ?? [])
+    .slice()
+    .sort((a, b) => (a.blob_index ?? 0) - (b.blob_index ?? 0));
 
   // Tab state management with URL search params
   const { selectedIndex, onChange } = useTabState([
@@ -927,7 +942,7 @@ export function DetailPage(): JSX.Element {
             {/* Blobs Tab - Blob data and submitters */}
             <TabPanel>
               <div className="space-y-6">
-                {blobCount === 0 && blobSubmitters.length === 0 ? (
+                {blobCount === 0 && blobDetails.length === 0 && blobSubmitters.length === 0 ? (
                   <Card>
                     <div className="py-8 text-center">
                       <p className="text-muted">No blob data available for this slot</p>
@@ -962,6 +977,42 @@ export function DetailPage(): JSX.Element {
                                 value={`${(effectiveBlockData.execution_payload_excess_blob_gas / 1e6).toFixed(2)}M`}
                               />
                             )}
+                        </div>
+                      </Card>
+                    )}
+
+                    {/* Blobs - one row per blob with its versioned hash + KZG commitment */}
+                    {blobDetails.length > 0 && (
+                      <Card>
+                        <div className="mb-4">
+                          <h3 className="text-lg font-semibold text-foreground">Blobs</h3>
+                          <p className="text-sm text-muted">
+                            {blobDetails.length} blob{blobDetails.length !== 1 ? 's' : ''} in this block
+                          </p>
+                        </div>
+                        <div className="grid gap-3">
+                          {blobDetails.map(blob => (
+                            <div
+                              key={`${blob.block_root}-${blob.blob_index}`}
+                              className="flex flex-col gap-2 rounded-sm border border-border bg-surface/50 p-4"
+                            >
+                              <div className="flex items-center justify-between gap-3">
+                                <span className="font-medium text-foreground">Blob {blob.blob_index}</span>
+                              </div>
+                              <div className="flex flex-col gap-1.5 text-xs">
+                                <div className="flex items-center gap-2">
+                                  <span className="shrink-0 text-muted">Versioned Hash:</span>
+                                  <code className="truncate font-mono text-foreground">{blob.versioned_hash}</code>
+                                  {blob.versioned_hash && <CopyToClipboard content={blob.versioned_hash} />}
+                                </div>
+                                <div className="flex items-center gap-2">
+                                  <span className="shrink-0 text-muted">KZG Commitment:</span>
+                                  <code className="truncate font-mono text-foreground">{blob.kzg_commitment}</code>
+                                  {blob.kzg_commitment && <CopyToClipboard content={blob.kzg_commitment} />}
+                                </div>
+                              </div>
+                            </div>
+                          ))}
                         </div>
                       </Card>
                     )}

--- a/src/pages/ethereum/slots/components/SlotDownloadModal/SlotDownloadModal.tsx
+++ b/src/pages/ethereum/slots/components/SlotDownloadModal/SlotDownloadModal.tsx
@@ -8,8 +8,13 @@ import { Alert } from '@/components/Feedback/Alert';
 import { CopyToClipboard } from '@/components/Elements/CopyToClipboard';
 import { fctBlockBlobHeadServiceListOptions } from '@/api/@tanstack/react-query.gen';
 import { getBlobDownloadUrl, getBlockDownloadUrl, type BlockDownloadFormat } from '@/utils';
+import { SLOTS_PER_EPOCH } from '@/utils/beacon';
+import { useBeaconClock } from '@/hooks/useBeaconClock';
 import { useArchiveDownload } from './useArchiveDownload';
 import type { SlotDownloadModalProps } from './SlotDownloadModal.types';
+
+// A slot's blobs are only archived once it finalizes (~2 epochs behind head).
+const FINALITY_LAG_SLOTS = 2 * SLOTS_PER_EPOCH;
 
 type TabKey = 'block' | 'blobs';
 
@@ -34,6 +39,11 @@ export function SlotDownloadModal({
 }: SlotDownloadModalProps): JSX.Element {
   const [tab, setTab] = useState<TabKey>('block');
   const { pendingKey, error, download } = useArchiveDownload();
+
+  // Blobs are not in the archive until the slot finalizes, so gate blob
+  // downloads on finality (block downloads are available much sooner).
+  const { slot: wallClockSlot } = useBeaconClock();
+  const blobsArchived = wallClockSlot - slot >= FINALITY_LAG_SLOTS;
 
   // Fetch the slot's blob versioned hashes from the head table (real-time,
   // unlike dim_block_blob_submitter which lags behind the chain head).
@@ -137,26 +147,30 @@ export function SlotDownloadModal({
                             <CopyToClipboard content={hash} successMessage="Versioned hash copied" />
                           </div>
                         </div>
-                        <Button
-                          variant="secondary"
-                          size="sm"
-                          rounded="sm"
-                          nowrap
-                          disabled={pendingKey === key}
-                          leadingIcon={
-                            pendingKey === key ? <ArrowPathIcon className="animate-spin" /> : <ArrowDownTrayIcon />
-                          }
-                          onClick={() => download(key, getBlobDownloadUrl(network, hash))}
-                        >
-                          Download
-                        </Button>
+                        <span title={blobsArchived ? undefined : 'Available once the slot finalizes (~13 min)'}>
+                          <Button
+                            variant="secondary"
+                            size="sm"
+                            rounded="sm"
+                            nowrap
+                            disabled={!blobsArchived || pendingKey === key}
+                            leadingIcon={
+                              pendingKey === key ? <ArrowPathIcon className="animate-spin" /> : <ArrowDownTrayIcon />
+                            }
+                            onClick={() => download(key, getBlobDownloadUrl(network, hash))}
+                          >
+                            {blobsArchived ? 'Download' : 'Pending'}
+                          </Button>
+                        </span>
                       </div>
                     );
                   })}
                 </div>
               </div>
               <p className="text-xs text-muted">
-                Raw blob bytes from the blob archive. Recently proposed blobs may not be archived yet.
+                {blobsArchived
+                  ? 'Raw blob bytes from the blob archive.'
+                  : 'Blobs are archived once the slot finalizes (~13 min) — downloads will be available then.'}
               </p>
             </div>
           ) : (


### PR DESCRIPTION
Two fixes to the slot detail blob UX, both driven by the live `fct_block_blob_head` table.

**Blobs panel card.** The detail-page Blobs tab only had a 'Blob Submitters' card sourced from `dim_block_blob_submitter`, which returns no rows (even for day-old slots), so the panel showed no blobs. Add a 'Blobs' card listing each blob's index, versioned hash, and KZG commitment from `fct_block_blob_head` (real-time).

**Finality-gated blob downloads.** A slot's blobs aren't in the blob archive until it finalizes (~2 epochs / ~13 min), so the modal's blob Download buttons now show a disabled 'Pending' state with an explanatory footer until then; they enable once finalized. Verified against the archive: a 4-min-old slot 404s, a 14-min-old slot returns 200. Block downloads remain available immediately. The gate (`wallClockSlot - slot >= 64`) flips reactively as the chain head advances.