### PR TITLE
feat(live): reimagine consensus Live page top bar as a slot HUD

### DIFF
--- a/src/components/Charts/Map2D/Map2D.tsx
+++ b/src/components/Charts/Map2D/Map2D.tsx
@@ -2,7 +2,13 @@ import type React from 'react';
 import { memo, useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import ReactECharts from 'echarts-for-react';
 import * as echarts from 'echarts';
-import type { Map2DChartProps, PointData, PointNodeData } from './Map2D.types';
+import type { Map2DChartProps, PointData, PointNodeData, RouteData } from './Map2D.types';
+
+// Stable empty-array defaults so an omitted prop doesn't produce a new reference
+// each render — that would recompute `option` and re-apply an empty scatter
+// series, wiping the streamed points and flickering the map.
+const EMPTY_ROUTES: RouteData[] = [];
+const EMPTY_POINTS: PointData[] = [];
 import { useThemeColors } from '@/hooks/useThemeColors';
 
 /**
@@ -27,8 +33,8 @@ interface HoveredPointInfo {
 }
 
 function Map2DChartComponent({
-  routes = [],
-  points = [],
+  routes = EMPTY_ROUTES,
+  points = EMPTY_POINTS,
   title,
   height = 600,
   showEffect = false,
@@ -221,6 +227,7 @@ function Map2DChartComponent({
       name: point.name,
       value: [...point.coords, point.value || 1],
       nodes: point.nodes,
+      ...(point.color ? { itemStyle: { color: point.color, shadowColor: point.color } } : {}),
     }));
 
     // Update the scatter series by stable ID to avoid index mismatches

--- a/src/components/Charts/Map2D/Map2D.types.ts
+++ b/src/components/Charts/Map2D/Map2D.types.ts
@@ -17,6 +17,7 @@ export interface PointData {
   name?: string;
   coords: [number, number]; // [longitude, latitude]
   value?: number; // Optional value for sizing the point
+  color?: string; // Optional per-point color (e.g. encoding arrival time); falls back to the series color
   nodes?: PointNodeData[]; // All nodes at this location for tooltip display
 }
 

--- a/src/constants/eip7870.ts
+++ b/src/constants/eip7870.ts
@@ -115,12 +115,15 @@ export function getClusterSpec(name: string): ClusterSpec | undefined {
   return CLUSTER_SPECS.find(spec => spec.name === name);
 }
 
+/** Marker substring identifying EIP-7870 reference nodes (in node names and node_class values). */
+export const EIP7870_REFERENCE_TAG = '7870';
+
 /**
  * Extract cluster name from a node name string
  * Returns the cluster name if the node is an EIP-7870 reference node, null otherwise
  */
 export function extractClusterFromNodeName(nodeName: string): string | null {
-  if (!nodeName.includes('7870')) return null;
+  if (!nodeName.includes(EIP7870_REFERENCE_TAG)) return null;
 
   // Transform the node name to extract the cluster prefix
   const shortName = nodeName

--- a/src/pages/ethereum/live/components/MobileSlotStats/MobileSlotStats.tsx
+++ b/src/pages/ethereum/live/components/MobileSlotStats/MobileSlotStats.tsx
@@ -1,0 +1,92 @@
+import { type JSX, type ReactNode } from 'react';
+import clsx from 'clsx';
+import { ClientLogo } from '@/components/Ethereum/ClientLogo';
+import { weiToEth } from '@/utils';
+import type { ClientValidationRow } from '../../hooks/useSlotViewData/useSlotViewData.types';
+import type { BlockDetailsData } from '../../hooks/useBlockDetailsData/useBlockDetailsData.types';
+
+export interface MobileSlotStatsProps {
+  clientValidation: ClientValidationRow[];
+  propagationP90Ms: number | null;
+  blockDetails: BlockDetailsData | null;
+  blobCount: number;
+  dataColumnBlobCount: number;
+}
+
+function formatEth(wei: string | null | undefined): string | null {
+  if (!wei) return null;
+  try {
+    const eth = weiToEth(wei);
+    if (!Number.isFinite(eth) || eth === 0) return null;
+    return eth < 0.001 ? eth.toFixed(4) : eth.toFixed(3);
+  } catch {
+    return null;
+  }
+}
+
+const STATUS_META: Record<string, { label: string; cls: string }> = {
+  canonical: { label: 'Proposed', cls: 'border-success/40 bg-success/10 text-success' },
+  orphaned: { label: 'Orphaned', cls: 'border-warning/40 bg-warning/10 text-warning' },
+  missed: { label: 'Missed', cls: 'border-danger/40 bg-danger/10 text-danger' },
+};
+
+function Chip({ label, children }: { label: string; children: ReactNode }): JSX.Element {
+  return (
+    <div className="flex shrink-0 items-baseline gap-1">
+      <span className="text-[9px] tracking-wide text-muted/70 uppercase">{label}</span>
+      <span className="font-mono text-xs font-semibold text-foreground tabular-nums">{children}</span>
+    </div>
+  );
+}
+
+/**
+ * MobileSlotStats — a compact, horizontally-scrollable strip of the key live
+ * slot metrics for the mobile layout (a condensed counterpart to the desktop
+ * SlotHud).
+ */
+export function MobileSlotStats({
+  clientValidation,
+  propagationP90Ms,
+  blockDetails,
+  blobCount,
+  dataColumnBlobCount,
+}: MobileSlotStatsProps): JSX.Element {
+  const fastest = clientValidation[0];
+  const bd = blockDetails;
+  const gasPct = bd?.gasUsed && bd?.gasLimit ? Math.round((bd.gasUsed / bd.gasLimit) * 100) : null;
+  const mevEth = formatEth(bd?.mevValue);
+  const blobs = dataColumnBlobCount || blobCount;
+  const statusMeta = bd?.status ? STATUS_META[bd.status] : null;
+
+  return (
+    <div className="flex h-full items-center gap-3 overflow-x-auto px-3">
+      {fastest && (
+        <div className="flex shrink-0 items-center gap-1">
+          <span className="text-[9px] tracking-wide text-muted/70 uppercase">Fast</span>
+          <ClientLogo client={fastest.client} size={12} />
+          <span className="font-mono text-xs font-semibold text-primary tabular-nums">{fastest.medianMs}ms</span>
+        </div>
+      )}
+      <Chip label="p90">{propagationP90Ms !== null ? `${(propagationP90Ms / 1000).toFixed(2)}s` : '—'}</Chip>
+      {mevEth && (
+        <div className="flex shrink-0 items-baseline gap-1">
+          <span className="text-[9px] tracking-wide text-muted/70 uppercase">MEV</span>
+          <span className="font-mono text-xs font-semibold text-success tabular-nums">{mevEth} Ξ</span>
+        </div>
+      )}
+      <Chip label="txs">{bd?.transactionCount != null ? bd.transactionCount.toLocaleString() : '—'}</Chip>
+      <Chip label="gas">{gasPct !== null ? `${gasPct}%` : '—'}</Chip>
+      <Chip label="blobs">{blobs > 0 ? blobs : '—'}</Chip>
+      {statusMeta && (
+        <span
+          className={clsx(
+            'shrink-0 rounded-sm border px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase',
+            statusMeta.cls
+          )}
+        >
+          {statusMeta.label}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/pages/ethereum/live/components/MobileSlotStats/index.ts
+++ b/src/pages/ethereum/live/components/MobileSlotStats/index.ts
@@ -1,0 +1,2 @@
+export { MobileSlotStats } from './MobileSlotStats';
+export type { MobileSlotStatsProps } from './MobileSlotStats';

--- a/src/pages/ethereum/live/components/SlotHud/SlotHud.tsx
+++ b/src/pages/ethereum/live/components/SlotHud/SlotHud.tsx
@@ -1,0 +1,277 @@
+import { type JSX, type ReactNode } from 'react';
+import clsx from 'clsx';
+import { ClientLogo } from '@/components/Ethereum/ClientLogo';
+import { weiToEth, weiToGwei } from '@/utils';
+import type { SlotHudProps } from './SlotHud.types';
+
+const MAX_CLIENTS = 6;
+
+function clampPct(value: number): number {
+  return Math.min(100, Math.max(0, value));
+}
+
+function secs(ms: number | null): string {
+  return ms !== null ? `${(ms / 1000).toFixed(2)}s` : '—';
+}
+
+/** Abbreviate a hex id (pubkey / root) to its leading bytes. */
+function shortHex(hex: string | null | undefined): string {
+  return hex ? `${hex.slice(0, 8)}…` : '—';
+}
+
+/** Render a count, falling back to an em-dash when absent. */
+function dash(n: number, format: (x: number) => ReactNode = String): ReactNode {
+  return n > 0 ? format(n) : '—';
+}
+
+/** Wei (string) → compact ETH string (e.g. "0.0089"), or null when zero/invalid. */
+function formatEth(wei: string | null | undefined): string | null {
+  if (!wei) return null;
+  try {
+    const eth = weiToEth(wei);
+    if (!Number.isFinite(eth) || eth === 0) return null;
+    return eth < 0.001 ? eth.toFixed(4) : eth.toFixed(3);
+  } catch {
+    return null;
+  }
+}
+
+/** Wei (string) → gwei number, or null when absent/invalid. */
+function gweiOrNull(wei: string | null | undefined): number | null {
+  if (!wei) return null;
+  try {
+    return weiToGwei(wei);
+  } catch {
+    return null;
+  }
+}
+
+const STATUS_META: Record<string, { label: string; cls: string }> = {
+  canonical: { label: 'Proposed', cls: 'border-success/40 bg-success/10 text-success' },
+  orphaned: { label: 'Orphaned', cls: 'border-warning/40 bg-warning/10 text-warning' },
+  missed: { label: 'Missed', cls: 'border-danger/40 bg-danger/10 text-danger' },
+};
+
+/** Fades content in once its data is active on the slot replay timeline. */
+function Fade({
+  active,
+  className,
+  children,
+}: {
+  active: boolean;
+  className?: string;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <div className={clsx('transition-opacity duration-700 ease-out', active ? 'opacity-100' : 'opacity-0', className)}>
+      {children}
+    </div>
+  );
+}
+
+/** A dense section: a topic label over a tight stack of stats. */
+function Section({
+  title,
+  accessory,
+  className,
+  children,
+}: {
+  title: string;
+  accessory?: ReactNode;
+  className?: string;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <div
+      className={clsx('flex min-w-0 flex-col gap-1 border-l border-border px-3 first:border-l-0 first:pl-0', className)}
+    >
+      <div className="flex h-3.5 items-center gap-2">
+        <span className="truncate text-[9px]/3 font-medium tracking-[0.16em] text-muted uppercase">{title}</span>
+        {accessory}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/** A single label → value line within a section. `title` shows the full value on hover when truncated. */
+function Row({ k, v, tone, title }: { k: string; v: ReactNode; tone?: string; title?: string }): JSX.Element {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <span className="shrink-0 text-[9px]/3 tracking-wide text-muted/60 uppercase">{k}</span>
+      <span
+        title={title}
+        className={clsx('truncate font-mono text-[11px]/3 font-semibold tabular-nums', tone ?? 'text-foreground')}
+      >
+        {v}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * SlotHud — a live dashboard strip of dense xatu-cbt sections for the consensus
+ * Live page: the EL-client validation race (engine_newPayload, 7870 reference
+ * nodes), block propagation, attestation timing, the MEV outcome and auction
+ * depth, the execution payload and block status. Each section's data fades in
+ * as it becomes active on the slot replay timeline.
+ */
+export function SlotHud({
+  currentTime,
+  clientValidation,
+  proposerEntity,
+  propagationMinMs,
+  propagationP50Ms,
+  propagationP90Ms,
+  propagationMaxMs,
+  propagationNodeCount,
+  attestationFirstMs,
+  attestationPeakMs,
+  attestationExpected,
+  blockDetails,
+  auctionBuilders,
+  auctionRelays,
+  auctionBids,
+  auctionTopRelay,
+  auctionTopBidWei,
+  blobCount,
+  dataColumnBlobCount,
+  className,
+}: SlotHudProps): JSX.Element {
+  // Reveal data only once the block has actually been seen on the network.
+  const blockActive = propagationMinMs !== null && currentTime >= propagationMinMs;
+
+  const clients = clientValidation.slice(0, MAX_CLIENTS);
+  const bd = blockDetails;
+
+  const gasPct = bd?.gasUsed && bd?.gasLimit ? clampPct((bd.gasUsed / bd.gasLimit) * 100) : null;
+  const gasUsedM = bd?.gasUsed != null ? `${(bd.gasUsed / 1e6).toFixed(1)}M` : null;
+  const baseGwei = gweiOrNull(bd?.baseFeePerGas);
+  const mevEth = formatEth(bd?.mevValue);
+  const topBidEth = formatEth(auctionTopBidWei);
+  const blobs = dataColumnBlobCount || blobCount;
+  const statusMeta = bd?.status ? STATUS_META[bd.status] : null;
+  const blockType = bd ? (mevEth ? 'mev-boost' : 'self-built') : null;
+
+  return (
+    <div className={clsx('flex h-[96px] w-full items-stretch', className)}>
+      {/* Validation race — 7870 reference nodes */}
+      <Section title="Validation · 7870" className="flex-[1.3]">
+        <div className="flex flex-col gap-px">
+          {clients.map((row, i) => (
+            <Fade
+              key={row.client}
+              active={propagationMinMs !== null && currentTime >= propagationMinMs + row.medianMs}
+              className="flex items-center gap-1.5"
+            >
+              <ClientLogo client={row.client} size={11} />
+              <span
+                title={row.client}
+                className={clsx('flex-1 truncate text-[10px]/3', i === 0 ? 'text-foreground' : 'text-muted')}
+              >
+                {row.client}
+              </span>
+              <span
+                className={clsx(
+                  'shrink-0 font-mono text-[10px]/3 tabular-nums',
+                  i === 0 ? 'font-semibold text-primary' : 'text-muted'
+                )}
+              >
+                {row.medianMs}ms
+              </span>
+            </Fade>
+          ))}
+        </div>
+      </Section>
+
+      {/* Propagation across the sentry network */}
+      <Section title="Propagation" className="flex-1">
+        <Fade active={blockActive} className="flex flex-col gap-px">
+          <Row k="first" v={secs(propagationMinMs)} />
+          <Row k="p50" v={secs(propagationP50Ms)} />
+          <Row k="p90" v={secs(propagationP90Ms)} tone="text-primary" />
+          <Row k="max" v={secs(propagationMaxMs)} />
+          <Row k="nodes" v={dash(propagationNodeCount)} />
+        </Fade>
+      </Section>
+
+      {/* Attestation arrival timing */}
+      <Section title="Attestation" className="flex-1">
+        <Fade active={blockActive} className="flex flex-col gap-px">
+          <Row k="first" v={secs(attestationFirstMs)} />
+          <Row k="peak" v={secs(attestationPeakMs)} />
+          <Row k="expected" v={dash(attestationExpected, n => n.toLocaleString())} />
+        </Fade>
+      </Section>
+
+      {/* MEV outcome */}
+      <Section title="MEV" className="flex-1">
+        <Fade active={blockActive} className="flex flex-col gap-px">
+          <Row k="value" v={mevEth ? `${mevEth} Ξ` : '—'} tone={mevEth ? 'text-success' : 'text-muted'} />
+          <Row k="via" v={bd?.mevRelays?.[0] ?? '—'} title={bd?.mevRelays?.join(', ') || undefined} />
+          <Row k="builder" v={shortHex(bd?.builderPubkey)} title={bd?.builderPubkey ?? undefined} />
+          <Row k="type" v={blockType ?? '—'} />
+        </Fade>
+      </Section>
+
+      {/* MEV auction depth (populated even when self-built) */}
+      <Section title="Auction" className="flex-1">
+        <Fade active={blockActive} className="flex flex-col gap-px">
+          <Row k="builders" v={dash(auctionBuilders)} />
+          <Row k="relays" v={dash(auctionRelays)} />
+          <Row k="bids" v={dash(auctionBids, n => n.toLocaleString())} />
+          <Row k="best" v={topBidEth ? `${topBidEth} Ξ` : '—'} tone={topBidEth ? 'text-success' : undefined} />
+          <Row k="top" v={auctionTopRelay ?? '—'} title={auctionTopRelay ?? undefined} />
+        </Fade>
+      </Section>
+
+      {/* Execution payload */}
+      <Section title="Execution" className="flex-1">
+        <Fade active={blockActive} className="flex flex-col gap-px">
+          <Row k="txns" v={bd?.transactionCount != null ? bd.transactionCount.toLocaleString() : '—'} />
+          <Row k="gas" v={gasPct !== null ? `${gasPct.toFixed(0)}%` : '—'} />
+          <Row k="used" v={gasUsedM ?? '—'} />
+          <Row k="base" v={baseGwei !== null ? `${baseGwei.toFixed(2)} gw` : '—'} />
+          <Row k="block" v={bd?.executionBlockNumber != null ? bd.executionBlockNumber.toLocaleString() : '—'} />
+          <Row k="blobs" v={dash(blobs)} />
+        </Fade>
+      </Section>
+
+      {/* Block */}
+      <Section
+        title="Block"
+        className="flex-[0.9]"
+        accessory={
+          statusMeta ? (
+            <Fade active={blockActive} className="ml-auto">
+              <span
+                className={clsx(
+                  'inline-block rounded-sm border px-1.5 py-0 text-[9px]/3 font-semibold tracking-wide uppercase',
+                  statusMeta.cls
+                )}
+              >
+                {statusMeta.label}
+              </span>
+            </Fade>
+          ) : undefined
+        }
+      >
+        <Fade active={blockActive} className="flex flex-col gap-px">
+          <Row k="fork" v={bd?.blockVersion || '—'} />
+          <Row
+            k="proposer"
+            v={proposerEntity ?? (bd?.proposerIndex != null ? `#${bd.proposerIndex}` : '—')}
+            tone={proposerEntity ? 'text-foreground' : 'text-muted'}
+            title={proposerEntity ?? (bd?.proposerIndex != null ? `Validator #${bd.proposerIndex}` : undefined)}
+          />
+          <Row k="root" v={shortHex(bd?.blockRoot)} title={bd?.blockRoot ?? undefined} />
+          <Row
+            k="on time"
+            v={bd?.wasOnTime === undefined ? '—' : bd.wasOnTime ? 'yes' : 'no'}
+            tone={bd?.wasOnTime ? 'text-success' : 'text-foreground'}
+          />
+        </Fade>
+      </Section>
+    </div>
+  );
+}

--- a/src/pages/ethereum/live/components/SlotHud/SlotHud.types.ts
+++ b/src/pages/ethereum/live/components/SlotHud/SlotHud.types.ts
@@ -1,0 +1,34 @@
+import type { ClientValidationRow } from '../../hooks/useSlotViewData/useSlotViewData.types';
+import type { BlockDetailsData } from '../../hooks/useBlockDetailsData/useBlockDetailsData.types';
+
+export interface SlotHudProps {
+  /** Live time within the slot, in milliseconds (0–12000) — gates fade-ins. */
+  currentTime: number;
+  /** EL client block-validation timings (7870 reference nodes), sorted fastest first. */
+  clientValidation: ClientValidationRow[];
+  /** Named staking entity that proposed the block, when known. */
+  proposerEntity: string | null;
+  /** Block propagation across the sentry network. */
+  propagationMinMs: number | null;
+  propagationP50Ms: number | null;
+  propagationP90Ms: number | null;
+  propagationMaxMs: number | null;
+  propagationNodeCount: number;
+  /** Attestation arrival timing + expected validator count. */
+  attestationFirstMs: number | null;
+  attestationPeakMs: number | null;
+  attestationExpected: number;
+  /** Full block details (status, gas, MEV, proposer, fork, …). */
+  blockDetails: BlockDetailsData | null;
+  /** MEV auction depth for the slot. */
+  auctionBuilders: number;
+  auctionRelays: number;
+  auctionBids: number;
+  auctionTopRelay: string | null;
+  auctionTopBidWei: string | null;
+  /** Blob counts (PeerDAS columns + legacy blob count). */
+  blobCount: number;
+  dataColumnBlobCount: number;
+  /** Optional CSS class name. */
+  className?: string;
+}

--- a/src/pages/ethereum/live/components/SlotHud/index.ts
+++ b/src/pages/ethereum/live/components/SlotHud/index.ts
@@ -1,0 +1,2 @@
+export { SlotHud } from './SlotHud';
+export type { SlotHudProps } from './SlotHud.types';

--- a/src/pages/ethereum/live/components/SlotViewLayout/SlotViewLayout.tsx
+++ b/src/pages/ethereum/live/components/SlotViewLayout/SlotViewLayout.tsx
@@ -12,17 +12,19 @@ import {
 } from 'react';
 import { useSlotPlayerState, useSlotPlayerActions, useSlotPlayerProgress } from '@/hooks/useSlotPlayer';
 import { useForks } from '@/hooks/useForks';
+import { useThemeColors } from '@/hooks/useThemeColors';
 import { Map2DChart } from '@/components/Charts/Map2D';
 import { Sidebar } from '../Sidebar';
 import type { SidebarProps } from '../Sidebar/Sidebar.types';
 import { MobileSlotHeader } from '../MobileSlotHeader';
-import { BlockDetailsCard } from '../BlockDetailsCard';
-import type { BlockDetailsCardProps } from '../BlockDetailsCard';
+import { MobileSlotStats } from '../MobileSlotStats';
+import { SlotHud } from '../SlotHud';
+import type { SlotHudProps } from '../SlotHud';
 import { BottomBar } from '../BottomBar';
 import type { BottomBarProps } from '../BottomBar';
 import { ScrollingTimeline } from '@/components/Lists/ScrollingTimeline';
 import { SlotTimeline } from '@/components/Ethereum/SlotTimeline';
-import { useSlotViewData, useSlotProgressData } from '../../hooks';
+import { useSlotViewData } from '../../hooks';
 import type { SlotViewLayoutProps, TimeFilteredData } from './SlotViewLayout.types';
 import type { MapPointWithTiming } from '../../hooks/useMapData/useMapData';
 import type { ContinentalPropagationSeries } from '../BlobDataAvailability/BlobDataAvailability.types';
@@ -131,14 +133,11 @@ function SlotLiveDataProvider({
       dataColumnFirstSeenData: [],
     };
     setDataVersion(prev => prev + 1);
-  }, [
-    currentSlot,
-    sortedMapPoints,
-    deduplicatedBlobTimeline,
-    sortedContinentalSeries,
-    attestationTimeToCount,
-    dataColumnFirstSeenData,
-  ]);
+    // Only reset on a genuine slot change. The grow effect below re-derives the
+    // visible sets from the latest data every tick, so resetting on mid-slot
+    // data-reference changes (e.g. background refetches) just clears and
+    // regrows the map — the source of the dot "flicker".
+  }, [currentSlot]);
 
   useEffect(() => {
     let mutated = false;
@@ -250,17 +249,14 @@ function SlotLiveDataProvider({
   return <SlotLiveDataContext.Provider value={value}>{children}</SlotLiveDataContext.Provider>;
 }
 
-interface BlockDetailsSectionProps {
-  data: BlockDetailsCardProps['data'];
-  slotProgressPhases: BlockDetailsCardProps['slotProgressPhases'];
-}
-
-const LiveBlockDetailsCard = memo(function LiveBlockDetailsCard({
-  data,
-  slotProgressPhases,
-}: BlockDetailsSectionProps) {
+const LiveSlotHud = memo(function LiveSlotHud({
+  currentSlot,
+  ...props
+}: Omit<SlotHudProps, 'currentTime'> & { currentSlot: number }) {
   const { slotProgress } = useSlotPlayerProgress();
-  return <BlockDetailsCard data={data} currentTime={slotProgress} slotProgressPhases={slotProgressPhases} />;
+  // Remount on slot change so a new slot starts fresh (faded out) instead of
+  // tweening from the previous slot's data.
+  return <SlotHud key={currentSlot} {...props} currentTime={slotProgress} />;
 });
 
 type SidebarStaticProps = Omit<SidebarProps, 'currentTime' | 'slotDuration'> & { slotDuration?: number };
@@ -320,19 +316,35 @@ interface LiveMapChartProps {
   height?: number | string;
 }
 
+// Color a node by how quickly it saw the block, on a fast→slow gradient
+// (green → terracotta → amber → red) so propagation speed reads geographically.
+function arrivalColor(
+  ms: number,
+  colors: { success: string; primary: string; warning: string; danger: string }
+): string {
+  if (ms < 1500) return colors.success;
+  if (ms < 2500) return colors.primary;
+  if (ms < 3500) return colors.warning;
+  return colors.danger;
+}
+
 const LiveMapChart = memo(function LiveMapChart({
   currentSlot,
   pointSizeMultiplier,
   height = '100%',
 }: LiveMapChartProps) {
   const { timeFilteredData } = useSlotLiveData();
+  const colors = useThemeColors();
+  const points = useMemo(
+    () =>
+      timeFilteredData.visibleMapPoints.map(point => ({
+        ...point,
+        color: arrivalColor(point.earliestSeenTime, colors),
+      })),
+    [timeFilteredData.visibleMapPoints, colors]
+  );
   return (
-    <Map2DChart
-      points={timeFilteredData.visibleMapPoints}
-      height={height}
-      pointSizeMultiplier={pointSizeMultiplier}
-      resetKey={currentSlot}
-    />
+    <Map2DChart points={points} height={height} pointSizeMultiplier={pointSizeMultiplier} resetKey={currentSlot} />
   );
 });
 
@@ -360,7 +372,6 @@ export function SlotViewLayout({ mode }: SlotViewLayoutProps): JSX.Element {
   const { activeFork } = useForks();
 
   const slotData = useSlotViewData(currentSlot);
-  const { phases: slotProgressPhases } = useSlotProgressData(slotData.rawApiData);
 
   const handleTimeClick = useCallback((timeMs: number) => actions.seekToTime(timeMs), [actions]);
 
@@ -412,7 +423,27 @@ export function SlotViewLayout({ mode }: SlotViewLayoutProps): JSX.Element {
       <>
         <div className="hidden h-screen flex-col overflow-hidden bg-background lg:flex">
           <div className="shrink-0 border-b border-border bg-surface px-6 py-2">
-            <LiveBlockDetailsCard data={slotData.blockDetails} slotProgressPhases={slotProgressPhases} />
+            <LiveSlotHud
+              currentSlot={currentSlot}
+              clientValidation={slotData.clientValidation}
+              proposerEntity={slotData.proposerEntity}
+              propagationMinMs={slotData.propagationMinMs}
+              propagationP50Ms={slotData.propagationP50Ms}
+              propagationP90Ms={slotData.propagationP90Ms}
+              propagationMaxMs={slotData.propagationMaxMs}
+              propagationNodeCount={slotData.propagationNodeCount}
+              attestationFirstMs={slotData.attestationFirstMs}
+              attestationPeakMs={slotData.attestationPeakMs}
+              attestationExpected={slotData.attestationTotalExpected}
+              blockDetails={slotData.blockDetails}
+              auctionBuilders={slotData.auctionBuilders}
+              auctionRelays={slotData.auctionRelays}
+              auctionBids={slotData.auctionBids}
+              auctionTopRelay={slotData.auctionTopRelay}
+              auctionTopBidWei={slotData.auctionTopBidWei}
+              blobCount={slotData.blobCount}
+              dataColumnBlobCount={slotData.dataColumnBlobCount}
+            />
           </div>
 
           <div className="grid min-h-0 flex-1 grid-cols-12">
@@ -461,6 +492,16 @@ export function SlotViewLayout({ mode }: SlotViewLayoutProps): JSX.Element {
               onBackward={actions.previousSlot}
               onForward={actions.nextSlot}
               isLive={mode === 'live'}
+            />
+          </div>
+
+          <div className="h-9 shrink-0 border-b border-border bg-surface">
+            <MobileSlotStats
+              clientValidation={slotData.clientValidation}
+              propagationP90Ms={slotData.propagationP90Ms}
+              blockDetails={slotData.blockDetails}
+              blobCount={slotData.blobCount}
+              dataColumnBlobCount={slotData.dataColumnBlobCount}
             />
           </div>
 

--- a/src/pages/ethereum/live/hooks/useSlotViewData/useSlotViewData.ts
+++ b/src/pages/ethereum/live/hooks/useSlotViewData/useSlotViewData.ts
@@ -4,7 +4,8 @@ import { useNetwork } from '@/hooks/useNetwork';
 import {
   fctBlockHeadServiceListOptions,
   fctBlockProposerServiceListOptions,
-  fctBlockMevServiceListOptions,
+  fctBlockProposerEntityServiceListOptions,
+  fctBlockMevHeadServiceListOptions,
   fctBlockBlobCountHeadServiceListOptions,
   fctBlockFirstSeenByNodeServiceListOptions,
   fctBlockBlobFirstSeenByNodeServiceListOptions,
@@ -13,7 +14,9 @@ import {
   intBeaconCommitteeHeadServiceListOptions,
   fctMevBidHighestValueByBuilderChunked50MsServiceListOptions,
   fctMevBidCountByRelayServiceListOptions,
+  fctEngineNewPayloadByElClientServiceListOptions,
 } from '@/api/@tanstack/react-query.gen';
+import { EIP7870_REFERENCE_TAG } from '@/constants';
 import { slotToTimestamp } from '../../utils';
 import { useBlockDetailsData } from '../useBlockDetailsData';
 import { useMapData } from '../useMapData';
@@ -28,6 +31,19 @@ const EMPTY_BLOCK_FIRST_SEEN: never[] = [];
 const EMPTY_BLOB_FIRST_SEEN: never[] = [];
 const EMPTY_DATA_COLUMN_FIRST_SEEN: never[] = [];
 const EMPTY_ATTESTATION: never[] = [];
+
+// Shared options for the per-slot queries. A given slot's data is essentially
+// settled once seen, so cache it and skip the window-focus refetch storm that
+// otherwise churns these arrays and flickers the live visualizations.
+const SLOT_QUERY_OPTIONS = {
+  staleTime: 60_000,
+  refetchOnWindowFocus: false,
+  retry: (failureCount: number, error: unknown): boolean => {
+    // 404 means no data for this slot — don't retry.
+    if (error && typeof error === 'object' && 'status' in error && error.status === 404) return false;
+    return failureCount < 3;
+  },
+};
 
 export function useSlotViewData(currentSlot: number): SlotViewData {
   const { currentNetwork } = useNetwork();
@@ -47,14 +63,7 @@ export function useSlotViewData(currentSlot: number): SlotViewData {
       },
     }),
     enabled: slotStartDateTime > 0,
-    retry: (failureCount, error) => {
-      // Don't retry on 404 - it means no data for this slot
-      if (error && typeof error === 'object' && 'status' in error && error.status === 404) {
-        return false;
-      }
-      // Retry other errors up to 3 times
-      return failureCount < 3;
-    },
+    ...SLOT_QUERY_OPTIONS,
   });
 
   // API Query 2: Block Proposer
@@ -66,25 +75,32 @@ export function useSlotViewData(currentSlot: number): SlotViewData {
       },
     }),
     enabled: slotStartDateTime > 0,
-    retry: (failureCount, error) => {
-      if (error && typeof error === 'object' && 'status' in error && error.status === 404) return false;
-      return failureCount < 3;
-    },
+    ...SLOT_QUERY_OPTIONS,
   });
 
-  // API Query 3: Block MEV
-  const blockMevQuery = useQuery({
-    ...fctBlockMevServiceListOptions({
+  // API Query 2b: Proposer Entity (named staker, when known)
+  const proposerEntityQuery = useQuery({
+    ...fctBlockProposerEntityServiceListOptions({
       query: {
         slot_start_date_time_eq: slotStartDateTime,
         page_size: 1,
       },
     }),
     enabled: slotStartDateTime > 0,
-    retry: (failureCount, error) => {
-      if (error && typeof error === 'object' && 'status' in error && error.status === 404) return false;
-      return failureCount < 3;
-    },
+    ...SLOT_QUERY_OPTIONS,
+  });
+
+  // API Query 3: Block MEV (head table — the canonical fct_block_mev lags and is
+  // empty for live slots, so use the head variant or every block reads self-built)
+  const blockMevQuery = useQuery({
+    ...fctBlockMevHeadServiceListOptions({
+      query: {
+        slot_start_date_time_eq: slotStartDateTime,
+        page_size: 1,
+      },
+    }),
+    enabled: slotStartDateTime > 0,
+    ...SLOT_QUERY_OPTIONS,
   });
 
   // API Query 4: Blob Count (using _head table for live data)
@@ -96,10 +112,7 @@ export function useSlotViewData(currentSlot: number): SlotViewData {
       },
     }),
     enabled: slotStartDateTime > 0,
-    retry: (failureCount, error) => {
-      if (error && typeof error === 'object' && 'status' in error && error.status === 404) return false;
-      return failureCount < 3;
-    },
+    ...SLOT_QUERY_OPTIONS,
   });
 
   // API Query 5: Block First Seen by Node (List)
@@ -111,10 +124,7 @@ export function useSlotViewData(currentSlot: number): SlotViewData {
       },
     }),
     enabled: slotStartDateTime > 0,
-    retry: (failureCount, error) => {
-      if (error && typeof error === 'object' && 'status' in error && error.status === 404) return false;
-      return failureCount < 3;
-    },
+    ...SLOT_QUERY_OPTIONS,
   });
 
   // API Query 6: Blob First Seen by Node (List)
@@ -126,10 +136,7 @@ export function useSlotViewData(currentSlot: number): SlotViewData {
       },
     }),
     enabled: slotStartDateTime > 0,
-    retry: (failureCount, error) => {
-      if (error && typeof error === 'object' && 'status' in error && error.status === 404) return false;
-      return failureCount < 3;
-    },
+    ...SLOT_QUERY_OPTIONS,
   });
 
   // API Query 6b: Data Column Sidecar First Seen (aggregated per column, not per node)
@@ -141,10 +148,7 @@ export function useSlotViewData(currentSlot: number): SlotViewData {
       },
     }),
     enabled: slotStartDateTime > 0,
-    retry: (failureCount, error) => {
-      if (error && typeof error === 'object' && 'status' in error && error.status === 404) return false;
-      return failureCount < 3;
-    },
+    ...SLOT_QUERY_OPTIONS,
   });
 
   // API Query 7: Attestation Chunked 50ms (List)
@@ -156,10 +160,7 @@ export function useSlotViewData(currentSlot: number): SlotViewData {
       },
     }),
     enabled: slotStartDateTime > 0,
-    retry: (failureCount, error) => {
-      if (error && typeof error === 'object' && 'status' in error && error.status === 404) return false;
-      return failureCount < 3;
-    },
+    ...SLOT_QUERY_OPTIONS,
   });
 
   // API Query 8: Beacon Committee (List) - for total expected validators
@@ -171,10 +172,7 @@ export function useSlotViewData(currentSlot: number): SlotViewData {
       },
     }),
     enabled: slotStartDateTime > 0,
-    retry: (failureCount, error) => {
-      if (error && typeof error === 'object' && 'status' in error && error.status === 404) return false;
-      return failureCount < 3;
-    },
+    ...SLOT_QUERY_OPTIONS,
   });
 
   // API Query 9: MEV Bidding Timeline (chunked 50ms)
@@ -186,10 +184,7 @@ export function useSlotViewData(currentSlot: number): SlotViewData {
       },
     }),
     enabled: slotStartDateTime > 0,
-    retry: (failureCount, error) => {
-      if (error && typeof error === 'object' && 'status' in error && error.status === 404) return false;
-      return failureCount < 3;
-    },
+    ...SLOT_QUERY_OPTIONS,
   });
 
   // API Query 10: MEV Bid Count by Relay
@@ -200,10 +195,20 @@ export function useSlotViewData(currentSlot: number): SlotViewData {
       },
     }),
     enabled: slotStartDateTime > 0,
-    retry: (failureCount, error) => {
-      if (error && typeof error === 'object' && 'status' in error && error.status === 404) return false;
-      return failureCount < 3;
-    },
+    ...SLOT_QUERY_OPTIONS,
+  });
+
+  // API Query 11: Engine newPayload validation timing per EL client
+  const engineByClientQuery = useQuery({
+    ...fctEngineNewPayloadByElClientServiceListOptions({
+      query: {
+        slot_start_date_time_eq: slotStartDateTime,
+        node_class_contains: EIP7870_REFERENCE_TAG,
+        page_size: 50,
+      },
+    }),
+    enabled: slotStartDateTime > 0,
+    ...SLOT_QUERY_OPTIONS,
   });
 
   // Aggregate loading state (critical queries only)
@@ -222,7 +227,7 @@ export function useSlotViewData(currentSlot: number): SlotViewData {
     if (blockHeadQuery.error) errorList.push({ endpoint: 'fct_block_head', error: blockHeadQuery.error as Error });
     if (blockProposerQuery.error)
       errorList.push({ endpoint: 'fct_block_proposer', error: blockProposerQuery.error as Error });
-    if (blockMevQuery.error) errorList.push({ endpoint: 'fct_block_mev', error: blockMevQuery.error as Error });
+    if (blockMevQuery.error) errorList.push({ endpoint: 'fct_block_mev_head', error: blockMevQuery.error as Error });
     if (blobCountQuery.error)
       errorList.push({ endpoint: 'fct_block_blob_count', error: blobCountQuery.error as Error });
     if (blockFirstSeenQuery.error)
@@ -261,7 +266,7 @@ export function useSlotViewData(currentSlot: number): SlotViewData {
   const blockDetails = useBlockDetailsData(
     blockHeadQuery.data?.fct_block_head?.[0],
     blockProposerQuery.data?.fct_block_proposer?.[0],
-    blockMevQuery.data?.fct_block_mev?.[0]
+    blockMevQuery.data?.fct_block_mev_head?.[0]
   );
 
   const mapPoints = useMapData(blockFirstSeenQuery.data?.fct_block_first_seen_by_node ?? EMPTY_BLOCK_FIRST_SEEN);
@@ -309,12 +314,126 @@ export function useSlotViewData(currentSlot: number): SlotViewData {
   // For now, just return 0 to avoid showing incorrect data
   const attestationActualCount = 0;
 
+  // EL client block-validation race, restricted to the EIP-7870 reference nodes
+  // (identical high-spec hardware) so client timings are a fair comparison.
+  // One row per client, sorted fastest first.
+  const clientValidation = useMemo(() => {
+    const rows = engineByClientQuery.data?.fct_engine_new_payload_by_el_client ?? [];
+    const byClient = new Map<string, { client: string; medianMs: number; observations: number }>();
+
+    for (const row of rows) {
+      if (row.status && row.status !== 'VALID') continue;
+      const client = row.meta_execution_implementation;
+      const median = row.median_duration_ms;
+      if (!client || median === undefined) continue;
+
+      const observations = row.observation_count ?? 0;
+      const existing = byClient.get(client);
+      // Keep the row backed by the most observations (most representative).
+      if (!existing || observations > existing.observations) {
+        byClient.set(client, { client, medianMs: median, observations });
+      }
+    }
+
+    return Array.from(byClient.values()).sort((a, b) => a.medianMs - b.medianMs);
+  }, [engineByClientQuery.data]);
+
+  // Block propagation across the sentry network (arrival ms percentiles).
+  const { propagationMinMs, propagationP50Ms, propagationP90Ms, propagationMaxMs, propagationNodeCount } =
+    useMemo(() => {
+      const diffs = (blockFirstSeenQuery.data?.fct_block_first_seen_by_node ?? EMPTY_BLOCK_FIRST_SEEN)
+        .map(node => node.seen_slot_start_diff)
+        .filter((d): d is number => typeof d === 'number')
+        .sort((a, b) => a - b);
+
+      if (diffs.length === 0) {
+        return {
+          propagationMinMs: null,
+          propagationP50Ms: null,
+          propagationP90Ms: null,
+          propagationMaxMs: null,
+          propagationNodeCount: 0,
+        };
+      }
+      const at = (q: number): number => diffs[Math.min(diffs.length - 1, Math.floor(q * (diffs.length - 1)))];
+      return {
+        propagationMinMs: diffs[0],
+        propagationP50Ms: at(0.5),
+        propagationP90Ms: at(0.9),
+        propagationMaxMs: diffs[diffs.length - 1],
+        propagationNodeCount: diffs.length,
+      };
+    }, [blockFirstSeenQuery.data]);
+
+  // Attestation arrival timing (reliable even though raw counts double-count):
+  // when the first vote was seen and when the arrival rate peaked.
+  const { attestationFirstMs, attestationPeakMs } = useMemo(() => {
+    let first: number | null = null;
+    let peakTime: number | null = null;
+    let peakCount = -1;
+    for (const point of attestationData) {
+      if (point.count <= 0) continue;
+      if (first === null || point.time < first) first = point.time;
+      if (point.count > peakCount) {
+        peakCount = point.count;
+        peakTime = point.time;
+      }
+    }
+    return { attestationFirstMs: first, attestationPeakMs: peakTime };
+  }, [attestationData]);
+
+  // MEV auction depth for the slot: how many builders/relays competed and the
+  // total bid volume — populated even when the proposer self-built.
+  const auction = useMemo(() => {
+    const builderRows = mevBiddingQuery.data?.fct_mev_bid_highest_value_by_builder_chunked_50ms ?? [];
+    const relayRows = relayBidsQuery.data?.fct_mev_bid_count_by_relay ?? [];
+
+    const builders = new Set(builderRows.map(bid => bid.builder_pubkey).filter(Boolean)).size;
+    let bids = 0;
+    let topRelay: string | null = null;
+    let topBids = -1;
+    for (const relay of relayRows) {
+      const count = relay.bid_total ?? 0;
+      bids += count;
+      if (count > topBids) {
+        topBids = count;
+        topRelay = relay.relay_name ?? null;
+      }
+    }
+
+    // Highest bid offered into the auction (in wei), regardless of what the proposer used.
+    let topBidWei: string | null = null;
+    let topBidValue = -1n;
+    for (const bid of builderRows) {
+      if (!bid.value) continue;
+      try {
+        const value = BigInt(bid.value);
+        if (value > topBidValue) {
+          topBidValue = value;
+          topBidWei = bid.value;
+        }
+      } catch {
+        // ignore malformed bid values
+      }
+    }
+
+    return {
+      auctionBuilders: builders,
+      auctionRelays: relayRows.length,
+      auctionBids: bids,
+      auctionTopRelay: topRelay,
+      auctionTopBidWei: topBidWei,
+    };
+  }, [mevBiddingQuery.data, relayBidsQuery.data]);
+
+  const proposerEntity = proposerEntityQuery.data?.fct_block_proposer_entity?.[0]?.entity ?? null;
+
   // Prepare raw API data for slot progress timeline
   const rawApiData = useMemo(
     () => ({
       blockHead: blockHeadQuery.data?.fct_block_head?.[0],
       blockProposer: blockProposerQuery.data?.fct_block_proposer?.[0],
-      blockMev: blockMevQuery.data?.fct_block_mev?.[0],
+      blockMev: blockMevQuery.data?.fct_block_mev_head?.[0],
       blockPropagation: blockFirstSeenQuery.data?.fct_block_first_seen_by_node ?? EMPTY_BLOCK_FIRST_SEEN,
       attestations: attestationQuery.data?.fct_attestation_first_seen_chunked_50ms ?? EMPTY_ATTESTATION,
       committees: committeeQuery.data?.int_beacon_committee_head ?? [],
@@ -349,6 +468,16 @@ export function useSlotViewData(currentSlot: number): SlotViewData {
       attestationTotalExpected,
       attestationActualCount,
       attestationMaxCount,
+      clientValidation,
+      proposerEntity,
+      propagationMinMs,
+      propagationP50Ms,
+      propagationP90Ms,
+      propagationMaxMs,
+      propagationNodeCount,
+      attestationFirstMs,
+      attestationPeakMs,
+      ...auction,
       isLoading,
       errors,
       rawApiData,
@@ -368,6 +497,16 @@ export function useSlotViewData(currentSlot: number): SlotViewData {
       attestationTotalExpected,
       attestationActualCount,
       attestationMaxCount,
+      clientValidation,
+      proposerEntity,
+      propagationMinMs,
+      propagationP50Ms,
+      propagationP90Ms,
+      propagationMaxMs,
+      propagationNodeCount,
+      attestationFirstMs,
+      attestationPeakMs,
+      auction,
       isLoading,
       errors,
       rawApiData,

--- a/src/pages/ethereum/live/hooks/useSlotViewData/useSlotViewData.types.ts
+++ b/src/pages/ethereum/live/hooks/useSlotViewData/useSlotViewData.types.ts
@@ -19,6 +19,16 @@ import type {
   FctMevBidCountByRelay,
 } from '@/api/types.gen';
 
+/** One EL client's engine_newPayload validation timing for a slot. */
+export interface ClientValidationRow {
+  /** Execution client implementation (e.g. Geth, Nethermind, Reth). */
+  client: string;
+  /** Median engine_newPayload duration in milliseconds. */
+  medianMs: number;
+  /** Number of node observations backing this row. */
+  observations: number;
+}
+
 export interface SlotViewData {
   // Block details (for slim card)
   blockDetails: BlockDetailsData | null;
@@ -45,6 +55,30 @@ export interface SlotViewData {
   attestationTotalExpected: number;
   attestationActualCount: number; // Actual count of validators who attested
   attestationMaxCount: number; // Max count across all time points for yMax
+
+  // EL client block-validation race (engine_newPayload timing), sorted fastest first
+  clientValidation: ClientValidationRow[];
+
+  // Named staking entity that proposed the block, when known (e.g. Lido)
+  proposerEntity: string | null;
+
+  // Block propagation across the sentry network (arrival ms percentiles)
+  propagationMinMs: number | null;
+  propagationP50Ms: number | null;
+  propagationP90Ms: number | null;
+  propagationMaxMs: number | null;
+  propagationNodeCount: number;
+
+  // Attestation arrival timing (ms from slot start)
+  attestationFirstMs: number | null;
+  attestationPeakMs: number | null;
+
+  // MEV auction depth for the slot
+  auctionBuilders: number;
+  auctionRelays: number;
+  auctionBids: number;
+  auctionTopRelay: string | null;
+  auctionTopBidWei: string | null;
 
   // State
   isLoading: boolean;


### PR DESCRIPTION
Replaces the sparse slot-phase strip on the Ethereum → Live page with a dense, live "slot HUD" built from xatu-cbt per-slot data: an EL-client engine_newPayload race on the EIP-7870 reference nodes, plus propagation, attestation timing, MEV outcome, MEV auction depth, execution payload, and block status, each fading in on the slot replay timeline, with a condensed mobile stat row. Also switches MEV to fct_block_mev_head (the canonical table is empty for live slots, so blocks previously read as self-built), colours the world-map nodes by propagation speed, fixes the map dot flicker, reduces live-query refetch churn, and adds hover tooltips on truncated values.