### PR TITLE
feat(gas-profiler): update Glamsterdam preset to frozen devnet-8 repricing

### DIFF
--- a/src/pages/ethereum/execution/gas-profiler/SimulatePage.types.ts
+++ b/src/pages/ethereum/execution/gas-profiler/SimulatePage.types.ts
@@ -320,41 +320,41 @@ export const GAS_PARAMETER_GROUPS: GasParameterGroup[] = [
 
 /**
  * Glamsterdam (EIP-8007) gas schedule preset.
- * Applies all gas parameter changes proposed for the Glamsterdam fork.
+ * Values match the frozen glamsterdam-devnet-8 repricing (ACDT #90).
  *
- * EIP-7904: Compute repricing (opcodes + precompiles)
+ * EIP-2780: Intrinsic transaction gas decomposition
  * EIP-7976: Calldata floor cost increase
- * EIP-2780: Transaction base cost reduction
- * EIP-8038: State access repricing (TBD - using current values as placeholders)
+ * EIP-7981: Access list data cost (folded into per-entry costs)
+ * EIP-8037: State creation gas (state-gas dimension folded into execution gas)
+ * EIP-8038: State access repricing
+ *
+ * EIP-7904 (compute repricing) is now Informational and recommends no changes,
+ * so the preset no longer overrides compute opcodes or precompiles.
  */
 export const GLAMSTERDAM_PRESET: Record<string, number> = {
-  // EIP-7904: Compute repricing
-  DIV: 15,
-  SDIV: 20,
-  MOD: 12,
-  MULMOD: 11,
-  KECCAK256: 45,
-  PC_BLAKE2F_BASE: 170,
-  PC_BLAKE2F_PER_ROUND: 2,
-  PC_BLS12_G1ADD: 643,
-  PC_BLS12_G2ADD: 765,
-  PC_BN254_ADD: 314,
-  PC_BN254_PAIRING_PER_PAIR: 34103,
-  PC_KZG_POINT_EVALUATION: 89363,
+  // EIP-2780: TX_BASE_COST; create tx intrinsic = TX_BASE_COST + CREATE_ACCESS (EIP-8038)
+  TX_BASE: 12000,
+  TX_CREATE_BASE: 24000,
 
   // EIP-7976: Calldata floor
-  TX_FLOOR_PER_TOKEN: 15,
+  TX_FLOOR_PER_TOKEN: 16,
 
-  // EIP-2780: TX base cost
-  TX_BASE: 4500,
+  // EIP-8038: State access repricing
+  CALL_COLD: 3000, // COLD_ACCOUNT_ACCESS
+  SSTORE_RESET: 12100, // SLOAD_COLD 2,100 + STORAGE_WRITE 10,000
+  CALL_VALUE_XFER: 11300, // CALL_VALUE = ACCOUNT_WRITE 9,000 + CALL_STIPEND 2,300
 
-  // EIP-8038: State access repricing (TBD - current values)
-  SLOAD_COLD: 2100,
-  SLOAD_WARM: 100,
-  SSTORE_RESET: 2900,
-  CALL_COLD: 2600,
-  TX_ACCESS_LIST_ADDR: 2400,
-  TX_ACCESS_LIST_KEY: 1900,
+  // EIP-8038 per-entry cost + EIP-7981 data cost (64 gas/byte)
+  TX_ACCESS_LIST_ADDR: 4180, // 2,900 + 1,280
+  TX_ACCESS_LIST_KEY: 4048, // 2,000 + 2,048
+
+  // EIP-8037: State creation gas (CPSB = 1,530 per state byte)
+  SSTORE_SET: 97920, // GAS_STORAGE_SET = 64 * CPSB
+  CALL_NEW_ACCOUNT: 183600, // GAS_NEW_ACCOUNT = 120 * CPSB
+  CREATE: 195600, // GAS_CREATE 183,600 + CREATE_ACCESS 12,000
+  CREATE2: 195600,
+  CREATE_DATA: 1530, // GAS_CODE_DEPOSIT per byte
+  TX_AUTH_COST: 35190, // PER_AUTH_BASE_COST = 23 * CPSB
 };
 
 /**

--- a/src/pages/ethereum/execution/gas-profiler/SimulatePage.types.ts
+++ b/src/pages/ethereum/execution/gas-profiler/SimulatePage.types.ts
@@ -23,7 +23,7 @@ export interface GasSchedule {
 
   // Storage - SSTORE (Istanbul+: EIP-2200 net metered)
   SSTORE_SET?: number; // Istanbul+: 20000
-  SSTORE_RESET?: number; // Istanbul+: 2900
+  SSTORE_RESET?: number; // Istanbul+: 5000 (legacy EIP-2200 value; backend charges SSTORE_RESET - SLOAD_COLD as the write surcharge)
 
   // Calls - access costs (pre-Berlin: single CALL_BASE, post-Berlin: cold/warm)
   CALL_BASE?: number; // pre-Berlin: varies by fork
@@ -123,8 +123,8 @@ export const GAS_PARAMETER_GROUPS: GasParameterGroup[] = [
       // Post-Berlin (EIP-2929): cold/warm access costs
       { key: 'SLOAD_COLD', label: 'SLOAD Cold', min: 0, max: 10000, step: 100 },
       { key: 'SLOAD_WARM', label: 'SLOAD Warm', min: 0, max: 1000, step: 10 },
-      { key: 'SSTORE_SET', label: 'SSTORE Set', min: 0, max: 50000, step: 1000 },
-      { key: 'SSTORE_RESET', label: 'SSTORE Reset', min: 0, max: 10000, step: 100 },
+      { key: 'SSTORE_SET', label: 'SSTORE Set', min: 0, max: 150000, step: 1000 },
+      { key: 'SSTORE_RESET', label: 'SSTORE Reset', min: 0, max: 25000, step: 100 },
     ],
   },
   {
@@ -145,9 +145,9 @@ export const GAS_PARAMETER_GROUPS: GasParameterGroup[] = [
       { key: 'CALL_COLD', label: 'CALL Cold', min: 0, max: 10000, step: 100 },
       { key: 'CALL_WARM', label: 'CALL Warm', min: 0, max: 1000, step: 10 },
       { key: 'CALL_VALUE_XFER', label: 'Value Transfer', min: 0, max: 20000, step: 500 },
-      { key: 'CALL_NEW_ACCOUNT', label: 'New Account', min: 0, max: 50000, step: 1000 },
-      { key: 'CREATE', label: 'CREATE', min: 0, max: 100000, step: 1000 },
-      { key: 'CREATE2', label: 'CREATE2', min: 0, max: 100000, step: 1000 },
+      { key: 'CALL_NEW_ACCOUNT', label: 'New Account', min: 0, max: 300000, step: 1000 },
+      { key: 'CREATE', label: 'CREATE', min: 0, max: 300000, step: 1000 },
+      { key: 'CREATE2', label: 'CREATE2', min: 0, max: 300000, step: 1000 },
       { key: 'SELFDESTRUCT', label: 'SELFDESTRUCT', min: 0, max: 10000, step: 100 },
     ],
   },

--- a/src/pages/ethereum/execution/gas-profiler/components/GasScheduleDrawer/GasScheduleDrawer.tsx
+++ b/src/pages/ethereum/execution/gas-profiler/components/GasScheduleDrawer/GasScheduleDrawer.tsx
@@ -59,25 +59,29 @@ interface CategoryGroup {
 }
 
 /**
- * Derive slider constraints from default value
+ * Derive slider constraints from the default value, widening the range to keep
+ * the current value (e.g. an applied preset) within the slider scale
  */
-function getSliderConstraints(defaultValue: number): { min: number; max: number; step: number } {
+function getSliderConstraints(
+  defaultValue: number,
+  currentValue: number = defaultValue
+): { min: number; max: number; step: number } {
   if (defaultValue === 0) {
-    return { min: 0, max: 100, step: 1 };
+    return { min: 0, max: Math.max(100, currentValue), step: 1 };
   }
   if (defaultValue <= 10) {
-    return { min: 0, max: Math.max(50, defaultValue * 5), step: 1 };
+    return { min: 0, max: Math.max(50, defaultValue * 5, currentValue), step: 1 };
   }
   if (defaultValue <= 100) {
-    return { min: 0, max: Math.max(500, defaultValue * 5), step: 10 };
+    return { min: 0, max: Math.max(500, defaultValue * 5, currentValue), step: 10 };
   }
   if (defaultValue <= 1000) {
-    return { min: 0, max: Math.max(5000, defaultValue * 5), step: 50 };
+    return { min: 0, max: Math.max(5000, defaultValue * 5, currentValue), step: 50 };
   }
   if (defaultValue <= 10000) {
-    return { min: 0, max: Math.max(50000, defaultValue * 5), step: 100 };
+    return { min: 0, max: Math.max(50000, defaultValue * 5, currentValue), step: 100 };
   }
-  return { min: 0, max: defaultValue * 5, step: 1000 };
+  return { min: 0, max: Math.max(defaultValue * 5, currentValue), step: 1000 };
 }
 
 /**
@@ -462,7 +466,7 @@ export function GasScheduleDrawer({
                                 if (!param) return null;
                                 const currentValue = schedule[key] ?? param.value;
                                 const isModified = schedule[key] !== undefined && schedule[key] !== param.value;
-                                const { min, max, step } = getSliderConstraints(param.value);
+                                const { min, max, step } = getSliderConstraints(param.value, currentValue);
 
                                 return (
                                   <div

--- a/src/pages/ethereum/execution/gas-profiler/components/GlamsterdamPresetModal/GlamsterdamPresetModal.tsx
+++ b/src/pages/ethereum/execution/gas-profiler/components/GlamsterdamPresetModal/GlamsterdamPresetModal.tsx
@@ -34,24 +34,16 @@ interface UnsupportedEip {
 /** EIP sections with overridable parameters */
 const EIP_SECTIONS: EipSection[] = [
   {
-    eip: 'EIP-7904',
-    name: 'Compute Repricing',
-    description: 'Adjusts gas costs for compute-heavy opcodes and precompiles to better reflect actual resource usage.',
-    url: 'https://eips.ethereum.org/EIPS/eip-7904',
+    eip: 'EIP-2780',
+    name: 'Intrinsic Transaction Gas',
+    description:
+      'Decomposes the flat 21,000 intrinsic cost into TX_BASE_COST (12,000) plus per-resource primitives; contract-creation intrinsic becomes TX_BASE_COST + CREATE_ACCESS (24,000).',
+    url: 'https://eips.ethereum.org/EIPS/eip-2780',
     parameters: [
-      { key: 'DIV', label: 'DIV' },
-      { key: 'SDIV', label: 'SDIV' },
-      { key: 'MOD', label: 'MOD' },
-      { key: 'MULMOD', label: 'MULMOD' },
-      { key: 'KECCAK256', label: 'KECCAK256' },
-      { key: 'PC_BLAKE2F_BASE', label: 'BLAKE2F Base' },
-      { key: 'PC_BLAKE2F_PER_ROUND', label: 'BLAKE2F /Round' },
-      { key: 'PC_BLS12_G1ADD', label: 'BLS12 G1Add' },
-      { key: 'PC_BLS12_G2ADD', label: 'BLS12 G2Add' },
-      { key: 'PC_BN254_ADD', label: 'BN254 Add' },
-      { key: 'PC_BN254_PAIRING_PER_PAIR', label: 'BN254 Pairing /Pair' },
-      { key: 'PC_KZG_POINT_EVALUATION', label: 'KZG Point Eval' },
+      { key: 'TX_BASE', label: 'TX Base' },
+      { key: 'TX_CREATE_BASE', label: 'TX Create Base' },
     ],
+    note: 'The decomposition itself (COLD_ACCOUNT_ACCESS and TX_VALUE_COST charged per transaction shape) cannot be expressed as overrides, so plain ETH transfers simulate at 12,000 instead of the decomposed 21,000.',
   },
   {
     eip: 'EIP-7976',
@@ -59,50 +51,56 @@ const EIP_SECTIONS: EipSection[] = [
     description: 'Increases the calldata floor cost per token, discouraging using calldata for data availability.',
     url: 'https://eips.ethereum.org/EIPS/eip-7976',
     parameters: [{ key: 'TX_FLOOR_PER_TOKEN', label: 'Floor Per Token' }],
-  },
-  {
-    eip: 'EIP-2780',
-    name: 'Transaction Repricing',
-    description:
-      'Reprices transaction costs: reduces the base cost from 21,000 to 4,500, and restructures value transfer and cold account access pricing.',
-    url: 'https://eips.ethereum.org/EIPS/eip-2780',
-    parameters: [{ key: 'TX_BASE', label: 'TX Base' }],
-    note: 'This EIP also introduces structural changes (new account surcharge, cold account cost splitting by code presence, value transfer repricing) that cannot be simulated as parameter overrides.',
+    note: 'The EIP also re-weights zero bytes to 4 tokens (64/64 per byte); token weights cannot be overridden, so zero bytes floor at 16 per byte here.',
   },
   {
     eip: 'EIP-8038',
     name: 'State Access Repricing',
     description:
-      'Reprices state access opcodes (SLOAD, SSTORE, CALL cold/warm). Values are still under discussion and may change.',
+      'Reprices state access: COLD_ACCOUNT_ACCESS 3,000, STORAGE_WRITE 10,000, CALL_VALUE 11,300, access list entries. Frozen for glamsterdam-devnet-8 (ACDT #90).',
     url: 'https://eips.ethereum.org/EIPS/eip-8038',
-    placeholder: true,
     parameters: [
-      { key: 'SLOAD_COLD', label: 'SLOAD Cold' },
-      { key: 'SLOAD_WARM', label: 'SLOAD Warm' },
+      { key: 'CALL_COLD', label: 'Cold Account Access' },
       { key: 'SSTORE_RESET', label: 'SSTORE Reset' },
-      { key: 'CALL_COLD', label: 'CALL Cold' },
+      { key: 'CALL_VALUE_XFER', label: 'Call Value' },
       { key: 'TX_ACCESS_LIST_ADDR', label: 'Access List Addr' },
       { key: 'TX_ACCESS_LIST_KEY', label: 'Access List Key' },
     ],
-    note: 'SSTORE clear refund and EXTCODESIZE/EXTCODECOPY formula changes in this EIP cannot be simulated as parameter overrides.',
+    note: 'SSTORE Reset is SLOAD_COLD 2,100 + STORAGE_WRITE 10,000. Access list entries include EIP-7981 data cost (1,280 per address, 2,048 per key). The raised storage-clear refund and the EXTCODESIZE/EXTCODECOPY extra warm read cannot be simulated as overrides.',
+  },
+  {
+    eip: 'EIP-8037',
+    name: 'State Creation Gas',
+    description:
+      'Prices state creation at a fixed 1,530 gas per state byte (CPSB): new account 183,600, storage set 97,920, code deposit 1,530 per byte, EIP-7702 auth 35,190.',
+    url: 'https://eips.ethereum.org/EIPS/eip-8037',
+    parameters: [
+      { key: 'SSTORE_SET', label: 'SSTORE Set' },
+      { key: 'CALL_NEW_ACCOUNT', label: 'New Account' },
+      { key: 'CREATE', label: 'CREATE' },
+      { key: 'CREATE2', label: 'CREATE2' },
+      { key: 'CREATE_DATA', label: 'Code Deposit /Byte' },
+      { key: 'TX_AUTH_COST', label: '7702 Auth' },
+    ],
+    note: 'The EIP meters these in a separate state-gas dimension with source-based refunds; the simulation folds them into execution gas, so blocks near the limit overestimate slightly.',
   },
 ];
 
 /** EIPs that involve structural changes and cannot be simulated via parameter overrides */
 const UNSUPPORTED_EIPS: UnsupportedEip[] = [
   {
-    eip: 'EIP-8037',
-    name: 'State Growth Costs',
+    eip: 'EIP-7904',
+    name: 'Compute Gas Cost Analysis',
     reason:
-      'Introduces new gas costs for account/storage creation that require protocol-level changes, not just parameter adjustments.',
-    url: 'https://eips.ethereum.org/EIPS/eip-8037',
+      'Now Informational: with EIP-7928 optimizations, compute opcodes and precompiles meet the throughput target at current costs, so no compute repricing is applied.',
+    url: 'https://eips.ethereum.org/EIPS/eip-7904',
   },
   {
-    eip: 'EIP-7981',
-    name: 'Access List Data Gas',
+    eip: 'EIP-7778',
+    name: 'Block Gas Accounting without Refunds',
     reason:
-      'Adds a new intrinsic gas mechanism for access list data that cannot be expressed as a simple price override.',
-    url: 'https://eips.ethereum.org/EIPS/eip-7981',
+      'Excludes gas refunds from block-level gas accounting, a structural change that cannot be expressed as a price override.',
+    url: 'https://eips.ethereum.org/EIPS/eip-7778',
   },
 ];
 
@@ -218,11 +216,13 @@ export function GlamsterdamPresetModal({
               EIP-8007 (Glamsterdam)
               <ArrowTopRightOnSquareIcon className="size-3.5" />
             </a>
-            , the upcoming Ethereum execution layer upgrade. It bundles compute repricing, calldata floor increases, and
-            transaction base cost reductions into a single preset you can simulate against real blocks.
+            , the upcoming Ethereum execution layer upgrade. It bundles state access and state creation repricing,
+            calldata floor increases, and the intrinsic transaction gas decomposition into a single preset you can
+            simulate against real blocks.
           </p>
           <p className="mt-2 text-sm/6 text-muted">
-            Values below are pre-filled with the proposed changes. You can adjust any parameter before simulating.
+            Values below are pre-filled with the frozen glamsterdam-devnet-8 repricing. You can adjust any parameter
+            before simulating.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary

Updates the Gas Repricing Simulator's Glamsterdam preset from the old draft values to the repricing frozen for **glamsterdam-devnet-8** (ACDT #90), and restructures the preset modal to match the current EIP set.

### Changes

- **EIP-7904 compute overrides removed** — the EIP is now Informational and recommends no compute repricing (EIP-7928 optimizations make current costs meet the 100 Mgas/s target).
- **EIP-2780**: `TX_BASE` 4,500 → **12,000** (`TX_BASE_COST`), new `TX_CREATE_BASE` **24,000** (`TX_BASE_COST` + `CREATE_ACCESS`).
- **EIP-7976**: `TX_FLOOR_PER_TOKEN` 15 → **16**.
- **EIP-8038** (no longer TBD placeholders): `CALL_COLD` **3,000**, `SSTORE_RESET` **12,100** (= `SLOAD_COLD` 2,100 + `STORAGE_WRITE` 10,000, matching erigone's `SSTORE_RESET − SLOAD_COLD` write surcharge), `CALL_VALUE_XFER` **11,300** (= `ACCOUNT_WRITE` 9,000 + stipend 2,300).
- **EIP-7981** folded into access-list entry costs: `TX_ACCESS_LIST_ADDR` **4,180** (2,900 + 1,280), `TX_ACCESS_LIST_KEY` **4,048** (2,000 + 2,048); removed from the "cannot simulate" list.
- **EIP-8037** now simulated (folded into execution gas, CPSB = 1,530/byte): `SSTORE_SET` **97,920**, `CALL_NEW_ACCOUNT` **183,600**, `CREATE`/`CREATE2` **195,600**, `CREATE_DATA` **1,530**, `TX_AUTH_COST` **35,190**; removed from the "cannot simulate" list.
- "Cannot simulate" list now carries EIP-7904 (informational) and EIP-7778 (refund exclusion from block accounting).

### Validation

Ran both presets through the live `simulate-block` API on recent mainnet blocks (25531333–25531362):

| Preset | Block gas delta | success→failed txs |
|---|---:|---:|
| old draft values (10 blocks) | **−21.9%** | 4 / ~3k |
| frozen devnet-8 values (30 blocks) | **+34.2%** (min +11.3% / max +47.9%) | 2,991 / 9,197 |

The stale preset materially misrepresents the fork: frozen devnet-8 pricing makes these blocks ~34% more expensive, 1 of 30 would exceed the block gas limit, and ~1/3 of txs flip to failed at their original gas limits (mostly out-of-gas from the state-creation costs) — which is exactly the txpool-across-the-fork behavior devnet-8 is stress-testing.

`pnpm typecheck` and eslint on `src/pages/ethereum/execution/gas-profiler` pass.
